### PR TITLE
Use -b flag for git checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/byu-oit/my-new-repo
 * Checkout the dev branch
 ```
 cd my-new-repo
-git checkout dev
+git checkout -b dev
 ```
 * Find all of the `.tf` files under `terraform-iac/dev/` and:
   * replace `<account_number>` with your account number.


### PR DESCRIPTION
Resolves a really tiny error:

`git checkout dev`
> error: pathspec 'dev' did not match any file(s) known to git

IIRC, when creating a repo from a template, only the default branch is copied. Hence, I only had a `master` branch and so the `dev` branch didn't exist.