### PR TITLE
Pull terraform-aws-ecr over HTTPS, bump version

### DIFF
--- a/terraform-iac/dev/setup/setup.tf
+++ b/terraform-iac/dev/setup/setup.tf
@@ -24,7 +24,7 @@ resource "aws_ssm_parameter" "some_secret" {
 }
 
 module "my_ecr" {
-  source               = "git@github.com:byu-oit/terraform-aws-ecr?ref=v1.0.1"
+  source               = "github.com/byu-oit/terraform-aws-ecr?ref=v1.1.0"
   name                 = "hello-world-api-dev"
   image_tag_mutability = "IMMUTABLE"
 

--- a/terraform-iac/prd/setup/setup.tf
+++ b/terraform-iac/prd/setup/setup.tf
@@ -24,7 +24,7 @@ resource "aws_ssm_parameter" "some_secret" {
 }
 
 module "my_ecr" {
-  source               = "git@github.com:byu-oit/terraform-aws-ecr?ref=v1.0.1"
+  source               = "github.com/byu-oit/terraform-aws-ecr?ref=v1.1.0"
   name                 = "hello-world-api-prd"
   image_tag_mutability = "IMMUTABLE"
 


### PR DESCRIPTION
Lehi just ran into an error when trying to do a `terraform init` since it tried to download the `terraform-aws-ecr` module using SSH.