### PR TITLE
don't assume we are building dev

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,8 +1,7 @@
 version: "0.2"
 artifacts:
   files:
-  - "./terraform-iac/dev/app/*"
-  - "./terraform-iac/modules/app/*"
+  - "./terraform-iac/**/*"
   - "*.tfvars"
   - "./tst/codedeploy-hooks/after-allow-test-traffic/lambda.zip"
 cache:


### PR DESCRIPTION
https://github.com/byu-oit/hello-world-api/blob/master/terraform-iac/modules/pipeline/pipeline.tf#L46 has already been updated to deploy the correct environment, but for this to work, we need to make the correct TF files available. I'd like to pass just the needed TF files, but I don't think you can use environment variables in the artifacts section of buildspec.yml. And I don't want to have multiple buildspec.yml files. So I'm passing all the TF files and just trusting the deploy phase to pick the correct ones (which it will, as long as we don't introduce a bug to pipeline.tf).