### PR TITLE
Bump setup-terraform action to v1.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v1.2.1
         with:
           terraform_version: ${{ env.tf_version }}
 
@@ -161,7 +161,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v1.2.1
         with:
           terraform_version: ${{ env.tf_version }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,7 +147,7 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPO:$IMAGE_TAG
 
       - name: Terraform Setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v1.2.1
         with:
           terraform_version: ${{ env.tf_version }}
 


### PR DESCRIPTION
It appears that Hashicorp is treating `v1` as an immutable tag,
so we're not getting minor version updates as we were expecting.

This update resolves CVE-2020-15228, so we shouldn't get as many
warnings related to `set-env` and `add-path`.