### PR TITLE
Cancel concurrent deployments instead of failing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Disallow Concurrent Runs
-        uses: byu-oit/github-action-disallow-concurrent-runs@v1
+        uses: byu-oit/github-action-disallow-concurrent-runs@v2
         with:
           token: ${{ github.token }}
 


### PR DESCRIPTION
This should cause the Deploy workflow to cancel itself instead of failing when a deployment is already running.

Refs: [the updates to `v2` of the action](https://github.com/byu-oit/github-action-disallow-concurrent-runs/releases/tag/v2.0.0)