### PR TITLE
fixed s3 bucket log bucket name

### DIFF
--- a/terraform-iac/modules/app/main.tf
+++ b/terraform-iac/modules/app/main.tf
@@ -86,7 +86,7 @@ module "my_fargate_api" {
 }
 
 resource "aws_s3_bucket" "my_lb_logs" {
-  bucket = "${local.name}-${var.env}"
+  bucket = "${local.name}-${var.env}-lb-logs"
   acl    = "log-delivery-write"
   tags   = local.tags
 }

--- a/terraform-iac/modules/app/main.tf
+++ b/terraform-iac/modules/app/main.tf
@@ -137,7 +137,7 @@ EOF
 # -----------------------------------------------------------------------------
 
 resource "aws_s3_bucket" "my_s3_bucket_logs" {
-  bucket = "${local.name}-${var.env}"
+  bucket = "${local.name}-${var.env}-logs"
   acl    = "log-delivery-write"
   tags   = local.tags
 }


### PR DESCRIPTION
s3 bucket log bucket was using the same name as the `my_s3_bucket` and needs to be a different bucket name