### PR TITLE
Use aws-sdk@v3 (broken down by service)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
     schedule:
       interval: daily
     target-branch: dev
-    ignore:
-      - dependency-name: aws-sdk
-        update-types: ['update:semver-patch'] # Ignore all
 
   - package-ecosystem: docker
     directory: '/src'

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 const express = require('express')
+const { DynamoDB } = require('@aws-sdk/client-dynamodb')
+const { S3 } = require('@aws-sdk/client-s3')
 const app = express()
-const AWS = require('aws-sdk')
-const dynamodb = new AWS.DynamoDB({ region: 'us-west-2' })
-const s3 = new AWS.S3()
+const dynamodb = new DynamoDB({ region: 'us-west-2' })
+const s3 = new S3({})
 
 app.use((req, res, next) => {
   console.log(`${req.method} called on ${req.path} on ${new Date().toISOString()}`)
@@ -18,8 +19,8 @@ app.get('/', async (req, res) => {
   const bucketParams = { Bucket: process.env.BUCKET_NAME }
   try {
     const [dynamoData, s3Data] = await Promise.all([
-      dynamodb.scan(dynamoParams).promise(),
-      s3.listObjectsV2(bucketParams).promise()
+      dynamodb.scan(dynamoParams),
+      s3.listObjectsV2(bucketParams)
     ])
     res.send({
       secret: process.env.SOME_SECRET,

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -4,6 +4,927 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.0.0.tgz",
+      "integrity": "sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.0.tgz",
+      "integrity": "sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.18.0.tgz",
+      "integrity": "sha512-AxDm2QLq2Z+PjzMESB+lPD5XL73MzC4CtUAajPn09ocWj7p9poVN0dd8NVFhBDfQMVPWTQaQBZk7h5TDvZrsBg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.18.0.tgz",
+      "integrity": "sha512-Xl4Dw67OgYEEqmPvcjcC4vvnZ7esAFKW32WRxhccfR0cqRhsM1RsDFHPfD8o5wJRiB3amc4Ui8ZbYBUy8a/2Fw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.18.0.tgz",
+      "integrity": "sha512-1ogm6vVt8qtRUOzExURHVspDPaLCOtahD5edsJeqPWUPNv5tGGaRi5LyZcXUTGky34Z4cVoy69FwxUBpkaJ6SA==",
+      "requires": {
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-dynamodb": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.18.0.tgz",
+      "integrity": "sha512-6na2CbMLj7MSSFX/6eU3GWuhj4Ch0QnDGmvDDtYv5NaMEd43SdwuoN/ufkQIPuORoqevcRpjCQFaQxoHvUucEA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.18.0",
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/credential-provider-node": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-signing": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "@aws-sdk/util-waiter": "3.18.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.18.0.tgz",
+      "integrity": "sha512-7qXl7Pg+/V0BxJNq+XRsj154clbKL9f4Jnx5pXO63ym/xhE9jxnJgi16/7krTBGkTCjVA0eYsj5d8wuJmJOdZA==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.18.0",
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/credential-provider-node": "3.18.0",
+        "@aws-sdk/eventstream-serde-browser": "3.18.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.18.0",
+        "@aws-sdk/eventstream-serde-node": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-blob-browser": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/hash-stream-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/md5-js": "3.18.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.18.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-expect-continue": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-location-constraint": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.18.0",
+        "@aws-sdk/middleware-sdk-s3": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-signing": "3.18.0",
+        "@aws-sdk/middleware-ssec": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "@aws-sdk/util-waiter": "3.18.0",
+        "@aws-sdk/xml-builder": "3.18.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.18.0.tgz",
+      "integrity": "sha512-OAS2R13NJ/mNnKxBc//Nva/+BmqaZZrzJ3pHsfGNUvzYE6rNj5iWHACD8LIV/Glf5Z3H52fbwfmYpwkMuvPuXQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.18.0.tgz",
+      "integrity": "sha512-xRaBx3A4Edd216ZSZP4360siOx7yGiPY2Ez/w4JbdcwFRjoen8cP9kTgbipgMhbwHVUvgNZpyDrCp0eRHL24bg==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/credential-provider-node": "3.18.0",
+        "@aws-sdk/fetch-http-handler": "3.18.0",
+        "@aws-sdk/hash-node": "3.18.0",
+        "@aws-sdk/invalid-dependency": "3.18.0",
+        "@aws-sdk/middleware-content-length": "3.18.0",
+        "@aws-sdk/middleware-host-header": "3.18.0",
+        "@aws-sdk/middleware-logger": "3.18.0",
+        "@aws-sdk/middleware-retry": "3.18.0",
+        "@aws-sdk/middleware-sdk-sts": "3.18.0",
+        "@aws-sdk/middleware-serde": "3.18.0",
+        "@aws-sdk/middleware-signing": "3.18.0",
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/middleware-user-agent": "3.18.0",
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/node-http-handler": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/smithy-client": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/url-parser": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "@aws-sdk/util-base64-node": "3.18.0",
+        "@aws-sdk/util-body-length-browser": "3.18.0",
+        "@aws-sdk/util-body-length-node": "3.18.0",
+        "@aws-sdk/util-user-agent-browser": "3.18.0",
+        "@aws-sdk/util-user-agent-node": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "@aws-sdk/util-utf8-node": "3.18.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.18.0.tgz",
+      "integrity": "sha512-2uSa/YccHckyYuY0OLDemgb+Jprif/NP+6OW+4eAjkwMGpZ3TtyGXoAZprBHqDXV12QxOYWjL6X6pyHvvsBAsQ==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.18.0.tgz",
+      "integrity": "sha512-+PajLjjpXib9rseqC/r8hnlgq5mOloIaTLYZsdbEC9Afwo5VmYlemL5gAfH+ABxYeanbTvHaP7lUNS3pLrM7dA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.18.0.tgz",
+      "integrity": "sha512-l/yDGjmZkkO0mSqatk7lOHKE6/EGplD5HHgAEY6pr5Y7C5a6ck7/mU7iNtmfq5HAv/YFsXHrewMGyXoE9iQBpg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.18.0.tgz",
+      "integrity": "sha512-Hsef5NC4hPh4BDlin/Eik9S2icFZIvQjPGVL2z3OO30Xer0GHwIQNMAf0WTREQ+cCuXFrIyCwSsdxIo1n2yQnA==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.18.0",
+        "@aws-sdk/credential-provider-imds": "3.18.0",
+        "@aws-sdk/credential-provider-web-identity": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.18.0.tgz",
+      "integrity": "sha512-iFwBl6w7mJAFo4YNVL960bkY6c4bUtABtbI+Wka8QbauGTGfAPMlET0JBesPNRAjkB7xzEtujPQL7pz4qlzeNQ==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.18.0",
+        "@aws-sdk/credential-provider-imds": "3.18.0",
+        "@aws-sdk/credential-provider-ini": "3.18.0",
+        "@aws-sdk/credential-provider-process": "3.18.0",
+        "@aws-sdk/credential-provider-sso": "3.18.0",
+        "@aws-sdk/credential-provider-web-identity": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.18.0.tgz",
+      "integrity": "sha512-0KwouUPsAALTqAlzy7HOddujjka3FmlNLe58bPPUk+2nqgg1qKGaNEtDTGCpusIaqLJm7ZbPJ0cJ8B+q/ytuwg==",
+      "requires": {
+        "@aws-sdk/credential-provider-ini": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.18.0.tgz",
+      "integrity": "sha512-EEHnWb/tFvFb9+a7dfChBdHmOZnqZeAbn6TOgc4LME4No9EG3XvkH48wxS0Mdhi9ziEGEdnNLQSVaIFzprWn8w==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.18.0",
+        "@aws-sdk/credential-provider-ini": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.18.0.tgz",
+      "integrity": "sha512-s+F9hE5f2hcrVluEWpDMCSAWUntNQyzJexQKq5KYdJuHsm+oQbACJwWPcB63rbmpzWQht88tU6+YeMRq8P9HIA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/endpoint-cache": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.18.0.tgz",
+      "integrity": "sha512-7gv52PYcMyDZsGSaxBtTC4eucK2oLnHzo+VkWIy/WJuh/r5oS26Xv6AA/1DSbGoqJQgi3AOWJJ2bCyzl1UcyQg==",
+      "requires": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.18.0.tgz",
+      "integrity": "sha512-DbvQfpBHolEanxjaJ3uJdfTdZdyE7Js7v2fvvYT/r59/zNYNNwUtjdciL25Dg2H4OfJtMp10r2neB23U5IKLVQ==",
+      "requires": {
+        "@aws-crypto/crc32": "^1.0.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-hex-encoding": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.18.0.tgz",
+      "integrity": "sha512-RDaRPyfXnabcLlci/PZAY7rqd7x2408kLiRNzpj824+yVgnjRlKG45YYkYggxZo2F4ZKVeU2rJE9zhxP9XT6AA==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.18.0",
+        "@aws-sdk/eventstream-serde-universal": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.18.0.tgz",
+      "integrity": "sha512-CDPwXQUiQbzFqGnn2QQSloRLZ6KogbGPqcAxVADdHiFw8+UdA+bjBbfQmmv0tTWvasrvPOLomHw42DZ1v+DvEw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.18.0.tgz",
+      "integrity": "sha512-EPg7QUxIAVHO5Zmp+9D8KYV3gcPvsz1v6nmw3ZFOGStgJM37j6KYbu84gFPradkEgTzE+bxb3OgB/mMC2j3XSg==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.18.0",
+        "@aws-sdk/eventstream-serde-universal": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.18.0.tgz",
+      "integrity": "sha512-pqQEFY4U16oV25vXAfaDnnTSe78ZDaqAEkVZxSt1gyfLBjin9AmFa4JpBx0TGbm5ZjwEk8KDwGa4+HPMTTQjxw==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.18.0.tgz",
+      "integrity": "sha512-jJS34wJzv+5wumVpQ7fGOmTxkJlu1tmGkbCt13xuSjYpt2M/by+WAShxcxEhrsBJlMNMHTHF+v2Tew6JwEP00w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/querystring-builder": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-base64-browser": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.18.0.tgz",
+      "integrity": "sha512-4+c/AoMLt50EeetoDhVKRq3CNnpHgrbQomQI4LjDZeSnlNuTZ/fQ6MvRnWPOoZgTwK2xtI31LrAt95G/54oa0Q==",
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.18.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.18.0.tgz",
+      "integrity": "sha512-rmjpJl4oG4JxHydnb9F3GzHu5wDJAQswgnBV0NszHfDndJm34f0Dta6OTmreK5nZ8ns/g6ZAjLjiTuKJoxjVmg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.18.0.tgz",
+      "integrity": "sha512-dW8nMYy4Wz5wjkID9z8e6cNdTVralDXfilgaPas7D+Q3RfnCm5PgDFHXFhDcY51rLwuuWCHmxi2QLqx9tGngmg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.18.0.tgz",
+      "integrity": "sha512-+VlXE8G22+H7d6K0EafpmihodOiF8I957J/euWIAGTSYYhLuAXPgCyPoKk1Qmxqfb3oAoG/cuoehCuPfFWwTPA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.18.0.tgz",
+      "integrity": "sha512-HvPRgESVQt0UbzRQZVKhf8SpGGc5Jrln3AtTzkVu6PBHO04Dh2EHsrsxiu7X3oB453Mnp8+LYBVIgsmM/RyJzA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.18.0.tgz",
+      "integrity": "sha512-EYYOdfl5i4o1XeaJYqQDk/3ETzLdzhR2JwqPxPGJfTC7E44yFJYV0fLFEmS46WXgN5Dtz4DXkw0GZdf/jJecyA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-utf8-browser": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-apply-body-checksum": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.18.0.tgz",
+      "integrity": "sha512-ODM+Lb89Zpuzmo/36O+PxfQb82Y1U8QG+BoLULdCYKGW0yqB6zywuHXhfJaTzSjZYufckVKPFaoKYUvE3GmPMw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.18.0.tgz",
+      "integrity": "sha512-MDNyGgPVf16vLOXbrRwiWqKc4muQwOaPHnKbx87w7M/MT4Uoq0d/r7rcCja2aEqr0iPLOxbRtASAhcPnQltxEA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-arn-parser": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.18.0.tgz",
+      "integrity": "sha512-N1qTzkn+vNjMXBRybW9/S9WtCFiJp2B8agr+41zja4hnZVA07kClvI76jM6KUwQHADB2q79FWT+i6PeyCHHh1Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.18.0.tgz",
+      "integrity": "sha512-8lwWrWb3ZZGkyaalZpB6TpXZUtfTOg5P1Bw11KcWE/EreavoXS59SBgf6aIWl74biM5WTk0F9wEiTGTQO38piw==",
+      "requires": {
+        "@aws-sdk/config-resolver": "3.18.0",
+        "@aws-sdk/endpoint-cache": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.18.0.tgz",
+      "integrity": "sha512-JiTx+22XRdC1MHp7wLdIuAIzgBVp/3EoAbSRdg4Qhs88yFwUZM7G3vNRtnq4l8He2T/VExVZjTLMcGBCKpu/pA==",
+      "requires": {
+        "@aws-sdk/middleware-header-default": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.18.0.tgz",
+      "integrity": "sha512-mWT/p2gVVB3us5Otf0g66zTIUaZXPMamatzmqEUVWC40VQxIcC0HeuXKBJrBQz63TqgFEUuFIPe5fdyaWgsjLQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.18.0.tgz",
+      "integrity": "sha512-MPX9GJk3Wl3OjRJ3ti+ptkG+7dTpXGtEjIPF0MsCSlfTKH01lsNGDpSZpeUyhYFrvl3fXoMrPeJHUuFeXA3bIA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.18.0.tgz",
+      "integrity": "sha512-VjMFFE7FXfmuwtFDnNLeqVM4/Q9rXC2a0YkYjXoGSzF4CuMarkyu3dPb590ubdSsYhYpKQDaoRFgJNzCRjmssA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.18.0.tgz",
+      "integrity": "sha512-GGiT4w8R7GOvlp4Q1w8JmBaBSsxNUL+ebEcs8ahJBrm9brYZG7tN8ncLXfF7d3oLd5XMoSbBkTn8+dQ973pkEQ==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.18.0.tgz",
+      "integrity": "sha512-PIvbtN05IftmbLACEdV6atNXJVuXNDkK5pcqKgggCteIKHz0QWnLUrgvi9wh2/HqDJD/XpY+ZmOEoZqUnwYSgg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/service-error-classification": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.18.0.tgz",
+      "integrity": "sha512-JQ0UGyixH3QTnLd27eG2rpgMswhe2T7e0h9iI9YLGDiYQLRAULYIagR6XZep1vKJljyY8VNmnII89aMb132I1w==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-arn-parser": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.18.0.tgz",
+      "integrity": "sha512-FVowN386wlLBt7ND5ALbkgJl65ynzxYNBH351mcD2/VwgCx3PZqZSr8sLoVDyuB+X2n9/GAI+r3W++zQ8YOymQ==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.18.0",
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.18.0.tgz",
+      "integrity": "sha512-46PtAvnGONN/v5OcNE4/3UywadCJunITwXDK/AGs6SMijkOPtoGMjP7fme9XlB6wg4QTSfeF3eKsieOF47RlPg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.18.0.tgz",
+      "integrity": "sha512-0DCwl1Hp66XVG3UUIvBhf7zy8pmeHFATInqRMF91Ch4mYJJdk/U0xLla+ouA2t6SjBkl2tb1bJLgjwkWnvR5Rg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/signature-v4": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.18.0.tgz",
+      "integrity": "sha512-j4WdgNLrHH5w5Nn3JbnMFFvTPTNU6a9FvLT08tfWYT93UOgRBe+d8c8BZzTY+OYkoA77EgEYuI5TYetratXiIw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.18.0.tgz",
+      "integrity": "sha512-+FDsKMRq3Gsd6ddVt1P+7ltSiRRcEj6KpRccMHkFkFqWWqn9OcPh+Et076ivSBXCW8q9Ib4qJi04hiCD/md2EQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.18.0.tgz",
+      "integrity": "sha512-BGm+buvq0wHtIylYGmyLhuRUvb2MsKx2mBhEx9m5Vs4M8I8GnTgrWtblOzwqZ+Q7dl+GQCL0/tLYTw50BTeLGQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.18.0.tgz",
+      "integrity": "sha512-U+qqNIWivZK9bd1BJMwRyXcTHZAS9r4sgPMrjFyOutdLxBCrhU7QUUr0hFaHdrsVA7cU+D3bBhFxq6JxGmj8Hg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.18.0",
+        "@aws-sdk/shared-ini-file-loader": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.18.0.tgz",
+      "integrity": "sha512-87ZxGlq3dnlPjAIN0yhawiF+n3oQQihxYaSeysltsuz13X/beYTDyGTEBZXWKwB06O/XHbfBV6iYUR7XgMP20w==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.18.0",
+        "@aws-sdk/protocol-http": "3.18.0",
+        "@aws-sdk/querystring-builder": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.18.0.tgz",
+      "integrity": "sha512-e7ADhSv8zAePAJLdXT0QItFPnA2ewOCDrD130E0NYA90AnW3xIyLB+J5HbwTWYUcF9Fbo0xSKh+0y8hBjNsT/w==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.18.0.tgz",
+      "integrity": "sha512-GIKvZBEnm87/mRaVYHnsQDYBSvU6qyKjyVdHDpQHhF+MZ+MKafygmpdBjsrRRstWr7h5WepnUVImYgvmaW6vyw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.18.0.tgz",
+      "integrity": "sha512-1DrzflLp80RG674XfhZsl4jehIe0mdSPqXqMH6vOMDcmF/lLEsfwPs307G+Go3kwWXSUup52bcMmfi8Ef4xLBg==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-uri-escape": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.18.0.tgz",
+      "integrity": "sha512-7pkgPCeTtsgcgBwYSK2QN9Kij88Adi4bKMBxCqpanloTng2KrZ3DfyyD7c0H70mt21Zqfwr2M1HrPSs1SZKBkw==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.18.0.tgz",
+      "integrity": "sha512-bgKy3fl1sIimpXUKqN9Mmb6tRtdtFQDYd/eX0LISSbdtJiVnMgiTxwTPEX72pN54L8zun3zU6xOuwoZP1Af6YA=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.18.0.tgz",
+      "integrity": "sha512-YpBCZWRvJhnPHbdFLzRvLIfx7Zxre8/5YsWrrNNBWRJ90z/6czzPdOn9jab/AVfLPpC/VSSubf4v4b8Cjeb4eA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.18.0.tgz",
+      "integrity": "sha512-md52+v+aIDfhwtaN+xIJ+7XgSqtRmreGkSCnJziGINRSnUSdycoR/ZJhT5d9TbMpYHdoT0Rm9RXNXImlfKCNGw==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "@aws-sdk/util-hex-encoding": "3.18.0",
+        "@aws-sdk/util-uri-escape": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.18.0.tgz",
+      "integrity": "sha512-fIcfzrf2TnhB4W8UyqdPQ9fPAfIfuLQ0dO/Y9qwzsw0Bvj4qYYPcUaNI2raX7WN1G2KHa9wZdiceR0J+uQO7yg==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.18.0.tgz",
+      "integrity": "sha512-fyk6HXK1wk83n4fDvsG+ewV+yS4uegepeMNrmLr7iBKjzc/bLckTWk7GKFM5ZaF/9jWyk7o2eKW3C3BltgDrfQ=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.18.0.tgz",
+      "integrity": "sha512-ye3sSF8R6kp1r98MRNk9UDj6P0luQfSZ5N2EZjF8AUG0y4PTVc4L/PlSsH3/sMOjG831al+khNo+cZNO9wZeiQ==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.18.0.tgz",
+      "integrity": "sha512-zqzkRwxbt73/SLZAmmLLqTavSF0BucButJQ5m9uIGgobPi7kZBjOwh4sY6WQw3E80MFc6EExiVyry3rSHiWMBg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.18.0.tgz",
+      "integrity": "sha512-XG7ls/9utSgCGzD0hgnNAQWLWU9Nnc/IqjQCZ6td84Y1/kTBBafSN3RTPeQ3fLzJ063sTDOy/DPEh21IPZCF6A==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.18.0.tgz",
+      "integrity": "sha512-NzkHCynFU2wfqU/15IkI5H0ukafu//LSUTFp9w4MzFNYpfbXAjcAK4S53VQe46bvciRRk8pyHc4wixiYsxFbpA==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.18.0.tgz",
+      "integrity": "sha512-+x0yrV9Z/gGGRVoWmx7t+skwG110vngkq5Clu7z+k/DtuZrkrspYKOVzidaH80pGJwJi+0JzxbIhA5JblBAf7Q==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.18.0.tgz",
+      "integrity": "sha512-r/m+TP9O1G8k9V51LvDCjkoc53Parn7BjP81cBplDrA6Uc2iezVRcjuXzRU+4X8EBIlUtCNhDYryl5xN8cohKw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.18.0.tgz",
+      "integrity": "sha512-4Pp4owEfjNdmqH9cByJnN0GbfM2II3I4FnRN5d9BysJ6mG+rLhc6WYxBgr4sEFtsJGYCgFzLU5MfUMx9OuDdPA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.18.0.tgz",
+      "integrity": "sha512-tayCN0+jLJRyM7W059ybwaEojjI4ylP4UyyG+LDc4m62PskmsCWTWOJzudjtx4d765e0I/F1w1ELrE+VhUdOpQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.18.0.tgz",
+      "integrity": "sha512-Lj2O9KaXCn+gPW23l3ydcSWe4HK0jH6teeSymbaFTwTjKtr4oLfDDKAOFoG5YyppQstEPqsL/RidVey4kOFfcg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.18.0.tgz",
+      "integrity": "sha512-Ui+uydvhzQALj/Q8sat4cVnCedwB/8iBPoMzcm1hr1r7ttWfmBKKElFZFl6ljCUtKaCE3rTb3JrZ2sKy9wT09A==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.18.0.tgz",
+      "integrity": "sha512-qBfyQJqN3RFyeY6nr03RZQ6uT6t5BIdthqwSPZ99K2gvf75TdhPA3PJsaIZfluNHEPQrgrNd32OED8jnd+GXwA==",
+      "requires": {
+        "@aws-sdk/types": "3.18.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.18.0.tgz",
+      "integrity": "sha512-gSdWW3X0kLMvooo2vc0yqWClclGUqcBfRq0K2w6XhYaJRT4E07KmQa4nPdBMYD1g79xW+53AbdQNnGq8b/bmhA==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.18.0.tgz",
+      "integrity": "sha512-JwcdTb6AAMtnlt2Sg0I18DBK1sWlsfDR/23CkDQ52niXvCSRdHeNkh5b7SdEPVUKI76hyce9nEshzI1OasTv7w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.18.0.tgz",
+      "integrity": "sha512-yQtKkW5V6ycT6DlJkYgeMjj6HJc+jj50LUUx2ukW6IfRmCeAGWdUu82NgIzlzvlsqH1jvmQ/kaeqZ7ruOtmA6Q==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.18.0.tgz",
+      "integrity": "sha512-ba67ZEn96RR7Nm0xXGtxD1ISWsG6ePpnOEi2p6hhP1/zJth70mCgxfMPHbxBmfQuadCtP3lhMGpRIptdAlXnDA==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.18.0",
+        "@aws-sdk/types": "3.18.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.18.0.tgz",
+      "integrity": "sha512-w8cx5Dx1njWjks+AH9tnQy6yvPbZUQrfJupvMFEY3wmXHnUGWCQrZC8GUOgcaLUbS27SykQAv+COxwNuZZMicQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -194,32 +1115,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "aws-sdk": {
-      "version": "2.922.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.922.0.tgz",
-      "integrity": "sha512-SufbR5TTCK94Zk/xIv4v/m0MM9z+KW999XnjXOyNWGFGHP9/FArjtHtq69+a3KpohYBR1dBj8wUhVjbClmQIBA==",
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -238,6 +1138,11 @@
         "type-is": "~1.6.17"
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -246,16 +1151,6 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "bytes": {
@@ -457,6 +1352,11 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -840,11 +1740,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -899,6 +1794,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "file-entry-cache": {
       "version": "5.0.1",
@@ -1085,11 +1985,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1246,18 +2141,14 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1425,6 +2316,14 @@
         "minimist": "^1.2.5"
       }
     },
+    "mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "requires": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1524,6 +2423,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.2"
       }
+    },
+    "obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -1778,20 +2682,10 @@
         "ipaddr.js": "1.9.1"
       }
     },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -1886,11 +2780,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "7.3.5",
@@ -2181,6 +3070,11 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2239,24 +3133,15 @@
         }
       }
     },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -2327,20 +3212,6 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "yallist": {
       "version": "4.0.0",

--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "aws-sdk": "^2.922.0",
+    "@aws-sdk/client-dynamodb": "^3.18.0",
+    "@aws-sdk/client-s3": "^3.18.0",
     "express": "^4.17.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I took out the `ignore` clause in the Dependabot config because these clients seem to get updated much less often.

Closes #213.