### PR TITLE
Fix dependabot.yml syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     target-branch: dev
     ignore:
       - dependency-name: node
-        update-types: ['update:semver-major'] # Stay within major version
+        update-types: ['version-update:semver-major'] # Stay within major version
 
   - package-ecosystem: github-actions
     directory: '/' # Check files in .github/workflows


### PR DESCRIPTION
Looks like I made a [mistake originally](https://github.com/byu-oit/hw-fargate-api/runs/2766550896).

In my defense, the [online validator](https://dependabot.com/docs/config-file/validator/) is out-of-date.

Refs: #217