### PR TITLE
Use concurrency in Deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 env:
   node_version: "14.x"
   tf_version: "0.14.7" # must match value in terraform-iac/*/app/main.tf
-
+concurrency: ${{ github.ref }}
 jobs:
   env:
     name: Set Env Vars
@@ -95,11 +95,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v2
-
-      - name: Disallow Concurrent Runs
-        uses: byu-oit/github-action-disallow-concurrent-runs@v2
-        with:
-          token: ${{ github.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Splitting out the bits of #173 that we all feel like we understand and can agree on.

When `concurrency` is defined at the workflow level, we're not subject to the indeterminate ordering that Josh mentioned in the other PR.