### PR TITLE
Add fail-fast: false to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,7 @@ jobs:
     needs: env
     strategy:
       matrix: ${{ fromJson(needs.env.outputs.matrix) }}
+      fail-fast: false
     steps:
       - name: Check out
         uses: actions/checkout@v2


### PR DESCRIPTION
To avoid canceling in-progress deployments if another one fails.

Inspired by [this canceled deployment](https://github.com/byu-oit/hw-lambda-api/runs/2786740467) over in [`hw-lambda-api`](https://github.com/byu-oit/hw-lambda-api).