### PR TITLE
Install dev deps during validation in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Build
         working-directory: src
-        run: npm ci --production --prefer-offline
+        run: npm ci --prefer-offline
 
       - name: Lint
         working-directory: src


### PR DESCRIPTION
If we're going to lint and test, we need `devDependencies`. ([Related deployment failure](https://github.com/byu-oit/hw-fargate-api/pull/233/checks?check_run_id=2842259111))

Note that the Docker build step is [still restricted to production dependencies](https://github.com/byu-oit/hw-fargate-api/blob/a0e553e351bd4b4aa115e921072a47f4a20fd64e/src/Dockerfile#L5).