### PR TITLE
Report test coverage to Codecov if CODECOV_TOKEN provided

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
         working-directory: src
         run: npm test
 
+      - name: Report test coverage to Codecov
+        uses: codecov/codecov-action@v1
+        if: env.CODECOV_TOKEN
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   audit:
     name: Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,12 @@ jobs:
         working-directory: src
         run: npm test
 
+      - name: Report test coverage to Codecov
+        uses: codecov/codecov-action@v1
+        if: env.CODECOV_TOKEN
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/src/package.json
+++ b/src/package.json
@@ -24,6 +24,7 @@
     "collectCoverage": true,
     "coverageDirectory": "coverage",
     "coverageReporters": [
+      "lcov",
       "text"
     ],
     "passWithNoTests": true,


### PR DESCRIPTION
If `CODECOV_TOKEN` is provided as a secret, the Codecov steps will run. If it isn't, those steps will be skipped. Hopefully, this is an implementation that can satisfy everyone. 🙂

<hr>

We used `env` here as a workaround because
```yaml
if: secrets.CODECOV_TOKEN
```
is invalid syntax. Conveniently, using `CODECOV_TOKEN` as an environment variable removes the need for
```yaml
with:
  token: secrets.CODECOV_TOKEN
```

<hr>

Thoughts? Is this something we _should_ do in the template?

Refs: #214