### PR TITLE
Use GHA caching built into `actions/setup-node@v2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.node_version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       - name: npm ci
         working-directory: src
@@ -107,6 +102,8 @@ jobs:
         with:
           node-version: ${{ env.node_version }}
 
+      # We don't need to install deps to audit them
+
       - name: npm audit
         working-directory: src
         run: npm audit --audit-level=critical
@@ -121,13 +118,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.node_version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       - name: npm ci
         working-directory: src

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,13 +109,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.node_version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
 
       - name: Audit
         working-directory: src


### PR DESCRIPTION
This was [announced on GitHub's blog](https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/). Unfortunately, because our application code is in a subdirectory we can't use it [quite yet](https://github.com/actions/setup-node#caching-packages-dependencies).
> At the moment, only `lock` files in the project root are supported.

So, this is a draft PR using the syntax described in [the ADR](https://github.com/actions/setup-node/pull/299), which will supposedly be [implemented in the coming months](https://github.com/actions/setup-node/issues/302#issuecomment-882481913).