### PR TITLE
Use GHA caching built into Docker Buildx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,14 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
-          install: true
+          version: v0.6.0
 
       - name: docker build
-        run: |
-          docker build src --file src/Dockerfile
+        uses: docker/build-push-action@v2
+        with:
+          context: src
+          cache-from: type=gha
+          cache-to: type=gha
 
   format:
     name: Terraform Format

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,14 +156,8 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          version: v0.6.0
 
       - name: Build and push the Docker image
         env:
@@ -175,16 +169,8 @@ jobs:
           context: src
           push: true
           tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPO}}:${{ env.IMAGE_TAG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      - # Temp fix
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-        name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha
 
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
The Docker actions can now natively use the GitHub Actions cache, though things [haven't quite gotten through the release pipeline](https://github.com/docker/build-push-action/pull/406#issuecomment-882754162).

This should work as-is, but once things have been released, we'll no longer need to explicitly use `v0.6.0` of Buildx.

Using `docker/build-push-action@v2` in CI allows us to get rid of
```yaml
with:
  install: true
```

If someone using this template were to build multiple Docker images, [they'd want to specify a `scope` to avoid cache collision/invalidation](https://github.com/docker/build-push-action/issues/252#issuecomment-881050512).