### PR TITLE
Stop specifying Buildx version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,6 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          version: v0.6.0
 
       - name: docker build
         uses: docker/build-push-action@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,8 +156,6 @@ jobs:
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          version: v0.6.0
 
       - name: Build and push the Docker image
         env:


### PR DESCRIPTION
Blocked until Buildx v0.6.0 is natively available in the GitHub virtual environments, which is when this badge shows that 100% of runners are on `20210726.1`, or a newer version. The percentage indicates rolling deployment progress.

[![ubuntu-20.04-badge](https://camo.githubusercontent.com/e455748de36bc2c067c36701208d1cc22a6642dfdb1b75371503622547fd28a8/68747470733a2f2f616374696f6e7669727475616c656e7669726f6e6d656e74737374617475732e617a75726577656273697465732e6e65742f6170692f7374617475733f696d6167654e616d653d7562756e747532302662616467653d31)](https://actionvirtualenvironmentsstatus.azurewebsites.net/api/status?imageName=ubuntu20&redirect=1)

Refs: https://github.com/byu-oit/hw-fargate-api/pull/272