### PR TITLE
Add SSE and abort incomplete multipart upload rule to log bucket

### DIFF
--- a/terraform-iac/modules/app/main.tf
+++ b/terraform-iac/modules/app/main.tf
@@ -132,6 +132,18 @@ resource "aws_s3_bucket" "my_s3_bucket_logs" {
   bucket = "${local.name}-${var.env}-logs"
   acl    = "log-delivery-write"
   tags   = local.tags
+  lifecycle_rule {
+    id                                     = "AutoAbortFailedMultipartUpload"
+    enabled                                = true
+    abort_incomplete_multipart_upload_days = 10
+  }
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket" "my_s3_bucket" {


### PR DESCRIPTION
We have another process automatically adding these, so this should reduce the diff in our Terraform plans.

[Example of TF plan before](https://github.com/byu-oit/hw-fargate-api/runs/3323353763?check_suite_focus=true#step:6:191)