### PR TITLE
Block access to log bucket

### DIFF
--- a/terraform-iac/modules/app/main.tf
+++ b/terraform-iac/modules/app/main.tf
@@ -134,6 +134,14 @@ resource "aws_s3_bucket" "my_s3_bucket_logs" {
   tags   = local.tags
 }
 
+resource "aws_s3_bucket_public_access_block" "default_logs" {
+  bucket                  = aws_s3_bucket.my_s3_bucket_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 resource "aws_s3_bucket" "my_s3_bucket" {
   bucket = "${local.name}-${var.env}"
   tags   = local.tags


### PR DESCRIPTION
Apart from an ID, this is identical to settings on the main bucket:
https://github.com/byu-oit/hw-fargate-api/blob/9f8414f897c30913a53e6bce740c49ba3a8a592f/terraform-iac/modules/app/main.tf#L164-L170