### PR TITLE
Cache intermediate Docker layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           context: src
           cache-from: type=gha
-          cache-to: type=gha
+          cache-to: type=gha,mode=max
 
   format:
     name: Terraform Format

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,7 +163,7 @@ jobs:
           push: true
           tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPO}}:${{ env.IMAGE_TAG }}
           cache-from: type=gha
-          cache-to: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Terraform Setup
         uses: hashicorp/setup-terraform@v1


### PR DESCRIPTION
This should be more useful for the general case since it'll be easier to re-use cached layers.