### PR TITLE
don't lock the terraform state on ci runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Terraform Plan
         working-directory: ${{ matrix.env.tf_working_dir }}
-        run: terraform plan -var 'image_tag=ci_test' -input=false -out plan
+        run: terraform plan -var 'image_tag=ci_test' -input=false -out plan -lock=false
 
       - name: Comment Terraform Plan
         uses: byu-oit/github-action-tf-plan-comment@v1


### PR DESCRIPTION
This makes the ci workflow not lock the state files so that if multiple dependabot PRs are created at the same time they don't all fail because of terraform locking issues.