### PR TITLE
Explicitly only run automerge when targeting `dev`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
     name: Automerge
     runs-on: ubuntu-latest
     needs: [test, audit, lint, docker, format, plan]
+    if: github.base_ref == 'dev'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Since this is used as a template, it's nice to be explicit about this.

Refs: https://github.com/byu-oit/hw-lambda-api/pull/243