### PR TITLE
replace resource tags with default tags

### DIFF
--- a/terraform-iac/cpy/app/main.tf
+++ b/terraform-iac/cpy/app/main.tf
@@ -18,8 +18,20 @@ terraform {
   }
 }
 
+locals {
+  env = "cpy"
+}
+
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      repo             = "https://github.com/byu-oit/hw-fargate-api"
+      data-sensitivity = "public"
+      env              = local.env
+    }
+  }
 }
 
 variable "image_tag" {
@@ -28,7 +40,7 @@ variable "image_tag" {
 
 module "app" {
   source                           = "../../modules/app/"
-  env                              = "cpy"
+  env                              = local.env
   image_tag                        = var.image_tag
   codedeploy_termination_wait_time = 15
   deploy_test_postman_collection   = "../../../.postman/hw-fargate-api.postman_collection.json"

--- a/terraform-iac/cpy/setup/setup.tf
+++ b/terraform-iac/cpy/setup/setup.tf
@@ -13,8 +13,20 @@ terraform {
   }
 }
 
+locals {
+  env = "cpy"
+}
+
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      repo             = "https://github.com/byu-oit/hw-fargate-api"
+      data-sensitivity = "public"
+      env              = local.env
+    }
+  }
 }
 
 variable "some_secret" {
@@ -24,6 +36,6 @@ variable "some_secret" {
 
 module "setup" {
   source      = "../../modules/setup/"
-  env         = "cpy"
+  env         = local.env
   some_secret = var.some_secret
 }

--- a/terraform-iac/dev/app/main.tf
+++ b/terraform-iac/dev/app/main.tf
@@ -18,8 +18,20 @@ terraform {
   }
 }
 
+locals {
+  env = "dev"
+}
+
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      repo             = "https://github.com/byu-oit/hw-fargate-api"
+      data-sensitivity = "public"
+      env              = local.env
+    }
+  }
 }
 
 variable "image_tag" {
@@ -28,7 +40,7 @@ variable "image_tag" {
 
 module "app" {
   source                           = "../../modules/app/"
-  env                              = "dev"
+  env                              = local.env
   image_tag                        = var.image_tag
   codedeploy_termination_wait_time = 0
   deploy_test_postman_collection   = "../../../.postman/hw-fargate-api.postman_collection.json"

--- a/terraform-iac/dev/setup/setup.tf
+++ b/terraform-iac/dev/setup/setup.tf
@@ -13,8 +13,20 @@ terraform {
   }
 }
 
+locals {
+  env = "dev"
+}
+
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      repo             = "https://github.com/byu-oit/hw-fargate-api"
+      data-sensitivity = "public"
+      env              = local.env
+    }
+  }
 }
 
 variable "some_secret" {
@@ -24,6 +36,6 @@ variable "some_secret" {
 
 module "setup" {
   source      = "../../modules/setup/"
-  env         = "dev"
+  env         = local.env
   some_secret = var.some_secret
 }

--- a/terraform-iac/modules/app/main.tf
+++ b/terraform-iac/modules/app/main.tf
@@ -24,11 +24,7 @@ variable "log_retention_days" {
 
 locals {
   name = "hw-fargate-api"
-  tags = {
-    env              = var.env
-    data-sensitivity = "public"
-    repo             = "https://github.com/byu-oit/${local.name}"
-  }
+  env  = var.env
 }
 
 data "aws_ecr_repository" "my_ecr_repo" {
@@ -58,7 +54,6 @@ module "my_fargate_api" {
   codedeploy_termination_wait_time = var.codedeploy_termination_wait_time
   role_permissions_boundary_arn    = module.acs.role_permissions_boundary.arn
   log_retention_in_days            = var.log_retention_days
-  tags                             = local.tags
 
   primary_container_definition = {
     name  = "${local.name}-${var.env}"
@@ -92,7 +87,6 @@ resource "aws_dynamodb_table" "my_dynamo_table" {
   name         = "${local.name}-${var.env}"
   hash_key     = "my_key_field"
   billing_mode = "PAY_PER_REQUEST"
-  tags         = local.tags
   attribute {
     name = "my_key_field"
     type = "S"
@@ -136,7 +130,6 @@ EOF
 resource "aws_s3_bucket" "my_s3_bucket_logs" {
   bucket = "${local.name}-${var.env}-logs"
   acl    = "log-delivery-write"
-  tags   = local.tags
   lifecycle_rule {
     id                                     = "AutoAbortFailedMultipartUpload"
     enabled                                = true
@@ -168,7 +161,6 @@ resource "aws_s3_bucket_public_access_block" "default_logs" {
 
 resource "aws_s3_bucket" "my_s3_bucket" {
   bucket = "${local.name}-${var.env}"
-  tags   = local.tags
   logging {
     target_bucket = aws_s3_bucket.my_s3_bucket_logs.id
     target_prefix = "log/"
@@ -252,7 +244,6 @@ module "postman_test_lambda" {
   ]
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
   log_retention_in_days         = var.log_retention_days
-  tags                          = local.tags
 }
 
 output "url" {

--- a/terraform-iac/modules/setup/setup.tf
+++ b/terraform-iac/modules/setup/setup.tf
@@ -8,22 +8,15 @@ variable "some_secret" {
 
 locals {
   name = "hw-fargate-api"
-  tags = {
-    env              = var.env
-    data-sensitivity = "public"
-    repo             = "https://github.com/byu-oit/${local.name}"
-  }
 }
 
 resource "aws_ssm_parameter" "some_secret" {
   name  = "/${local.name}/${var.env}/some-secret"
   type  = "SecureString"
   value = var.some_secret
-  tags  = local.tags
 }
 
 module "my_ecr" {
   source = "github.com/byu-oit/terraform-aws-ecr?ref=v2.0.1"
   name   = "${local.name}-${var.env}"
-  tags   = local.tags
 }

--- a/terraform-iac/prd/app/main.tf
+++ b/terraform-iac/prd/app/main.tf
@@ -18,8 +18,20 @@ terraform {
   }
 }
 
+locals {
+  env = "prd"
+}
+
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      repo             = "https://github.com/byu-oit/hw-fargate-api"
+      data-sensitivity = "public"
+      env              = local.env
+    }
+  }
 }
 
 variable "image_tag" {
@@ -28,7 +40,7 @@ variable "image_tag" {
 
 module "app" {
   source                           = "../../modules/app/"
-  env                              = "prd"
+  env                              = local.env
   image_tag                        = var.image_tag
   codedeploy_termination_wait_time = 15
   deploy_test_postman_collection   = "../../../.postman/hw-fargate-api.postman_collection.json"

--- a/terraform-iac/prd/setup/setup.tf
+++ b/terraform-iac/prd/setup/setup.tf
@@ -13,8 +13,20 @@ terraform {
   }
 }
 
+locals {
+  env = "prd"
+}
+
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      repo             = "https://github.com/byu-oit/hw-fargate-api"
+      data-sensitivity = "public"
+      env              = local.env
+    }
+  }
 }
 
 variable "some_secret" {
@@ -24,6 +36,6 @@ variable "some_secret" {
 
 module "setup" {
   source      = "../../modules/setup/"
-  env         = "prd"
+  env         = local.env
   some_secret = var.some_secret
 }

--- a/terraform-iac/stg/app/main.tf
+++ b/terraform-iac/stg/app/main.tf
@@ -18,8 +18,19 @@ terraform {
   }
 }
 
+locals {
+  env = "stg"
+}
+
 provider "aws" {
   region = "us-west-2"
+  default_tags {
+    tags = {
+      repo             = "https://github.com/byu-oit/hw-fargate-api"
+      data-sensitivity = "public"
+      env              = local.env
+    }
+  }
 }
 
 variable "image_tag" {
@@ -28,7 +39,7 @@ variable "image_tag" {
 
 module "app" {
   source                           = "../../modules/app/"
-  env                              = "stg"
+  env                              = local.env
   image_tag                        = var.image_tag
   codedeploy_termination_wait_time = 0
   deploy_test_postman_collection   = "../../../.postman/hw-fargate-api.postman_collection.json"

--- a/terraform-iac/stg/setup/setup.tf
+++ b/terraform-iac/stg/setup/setup.tf
@@ -13,8 +13,20 @@ terraform {
   }
 }
 
+locals {
+  env = "stg"
+}
+
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      repo             = "https://github.com/byu-oit/hw-fargate-api"
+      data-sensitivity = "public"
+      env              = local.env
+    }
+  }
 }
 
 variable "some_secret" {
@@ -24,6 +36,6 @@ variable "some_secret" {
 
 module "setup" {
   source      = "../../modules/setup/"
-  env         = "stg"
+  env         = local.env
   some_secret = var.some_secret
 }


### PR DESCRIPTION
This PR addresses [issue 385](https://github.com/byu-oit/hw-fargate-api/issues/385) by replacing the repetitive resource tags with AWS default tags. This way, every resource made with this provider has the same tags by default. 