### PR TITLE
Update dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,7 @@ updates:
       interval: daily
     target-branch: dev
 
-# For each of these, requesting reviews from yourself makes Dependabot PRs easier to find (https://github.com/pulls/review-requested)
-    reviewers:
-      - byu-oit/devops-tooling
-      - byu-oit/devx
+# For each of these, requesting reviews from your team makes Dependabot PRs easier to find (https://github.com/pulls/review-requested)
+#     reviewers:
+#       - byu-oit/devops-tooling
+#       - byu-oit/devx

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,5 @@ updates:
     target-branch: dev
 
 # For each of these, requesting reviews from your team makes Dependabot PRs easier to find (https://github.com/pulls/review-requested)
-#     reviewers:
-#       - byu-oit/devops-tooling
-#       - byu-oit/devx
+#   reviewers:
+#     - byu-oit/your-github-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,5 +47,6 @@ updates:
     target-branch: dev
 
 # For each of these, requesting reviews from yourself makes Dependabot PRs easier to find (https://github.com/pulls/review-requested)
-#    reviewers:
-#      - "YourGitHubUsername"
+    reviewers:
+      - byu-oit/devops-tooling
+      - byu-oit/devx


### PR DESCRIPTION
Update dependabot to use teams instead of users as reviewers for each repo.