### PR TITLE
Use `npm ci --omit=dev` instead of `npm ci --production`

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.18.0
 WORKDIR /usr/app
 
 COPY package*.json ./
-RUN npm ci --production
+RUN npm ci --omit=dev
 
 COPY app.js server.js ./
 


### PR DESCRIPTION
Resolves
```sh
npm ci --production
```
giving us the following warning:
```sh
npm WARN config production Use `--omit=dev` instead.
```