### PR TITLE
Split up CI

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -1,0 +1,113 @@
+name: CI / App
+
+on:
+  pull_request:
+    branches: [dev, stg, prd]
+    types: [opened, reopened, synchronize, edited]
+    paths:
+      - 'src/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/ci-app.yml'
+
+env:
+  node_version: "18.x"
+  FORCE_COLOR: 3
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: npm ci
+        working-directory: src
+        run: npm ci --prefer-offline
+
+      - name: npm test
+        working-directory: src
+        run: npm test
+
+      - name: Report test coverage to Codecov
+        uses: codecov/codecov-action@v3
+        if: env.CODECOV_TOKEN
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node_version }}
+
+      # We don't need to install deps to audit them
+
+      - name: npm audit
+        working-directory: src
+        run: npm audit --audit-level=critical
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: npm ci
+        working-directory: src
+        run: npm ci --prefer-offline
+
+      - name: npm lint
+        working-directory: src
+        run: npm run lint
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: docker build
+        uses: docker/build-push-action@v3
+        with:
+          context: src
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  automerge:
+    if: github.base_ref == 'dev' # Only automerge into dev branch
+    name: Automerge
+    runs-on: ubuntu-latest
+    needs: [test, audit, lint, docker]
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Auto-merge Dependabot Pull Request
+        uses: fastify/github-action-merge-dependabot@v3.4.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: minor

--- a/.github/workflows/ci-iac.yml
+++ b/.github/workflows/ci-iac.yml
@@ -1,13 +1,15 @@
-name: CI
+name: CI / IaC
 
 on:
   pull_request:
     branches: [dev, stg, prd]
     types: [opened, reopened, synchronize, edited]
+    paths:
+      - 'terraform-iac/**'
+      - '.github/workflows/ci-iac.yml'
+
 env:
-  node_version: "18.x"
   tf_version: "1.3.2" # must match value in terraform-iac/*/app/main.tf
-  FORCE_COLOR: 3
 
 jobs:
   env:
@@ -64,94 +66,9 @@ jobs:
     outputs:
       matrix: ${{ env.matrix }}
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.node_version }}
-          cache: npm
-          cache-dependency-path: '**/package-lock.json'
-
-      - name: npm ci
-        working-directory: src
-        run: npm ci --prefer-offline
-
-      - name: npm test
-        working-directory: src
-        run: npm test
-
-      - name: Report test coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: env.CODECOV_TOKEN
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  audit:
-    name: Audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.node_version }}
-
-      # We don't need to install deps to audit them
-
-      - name: npm audit
-        working-directory: src
-        run: npm audit --audit-level=critical
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.node_version }}
-          cache: npm
-          cache-dependency-path: '**/package-lock.json'
-
-      - name: npm ci
-        working-directory: src
-        run: npm ci --prefer-offline
-
-      - name: npm lint
-        working-directory: src
-        run: npm run lint
-
-  docker:
-    name: Docker Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: docker build
-        uses: docker/build-push-action@v3
-        with:
-          context: src
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   format:
     name: Terraform Format
     runs-on: ubuntu-latest
-    needs: env
-    strategy:
-      matrix: ${{ fromJson(needs.env.outputs.matrix) }}
-      fail-fast: false
     steps:
       - uses: actions/checkout@v3
 
@@ -161,7 +78,7 @@ jobs:
           terraform_version: ${{ env.tf_version }}
 
       - name: Terraform Format
-        working-directory: "./"
+        working-directory: terraform-iac
         run: terraform fmt -check -recursive
 
   plan:
@@ -217,7 +134,7 @@ jobs:
     if: github.base_ref == 'dev' # Only automerge into dev branch
     name: Automerge
     runs-on: ubuntu-latest
-    needs: [test, audit, lint, docker, format, plan]
+    needs: [format, plan]
     permissions:
       pull-requests: write
       contents: write
@@ -229,4 +146,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor
-


### PR DESCRIPTION
Closes #651

Auto-merging is simpler than I originally anticipated: Dependabot PRs updating Terraform don't need application CI, and Dependabot PRs updating application code don't need Terraform CI.