### PR TITLE
Use `@v3` and `continue-on-error` for auto-merge step

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -113,7 +113,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Auto-merge Dependabot Pull Request
-        uses: fastify/github-action-merge-dependabot@v3.4.1
+        uses: fastify/github-action-merge-dependabot@v3
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor

--- a/.github/workflows/ci-iac.yml
+++ b/.github/workflows/ci-iac.yml
@@ -144,7 +144,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Auto-merge Dependabot Pull Request
-        uses: fastify/github-action-merge-dependabot@v3.4.1
+        uses: fastify/github-action-merge-dependabot@v3
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: minor


### PR DESCRIPTION
According to [the docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error), `continue-on-error`:
> Prevents a job from failing when a step fails. Set to `true` to allow a job to pass when this step fails.

Closes: #646 