### PR TITLE
Split up `Deploy` workflow into multiple jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,16 +87,9 @@ jobs:
     outputs:
       matrix: ${{ env.matrix }}
 
-  build_and_deploy:
-    name: Build and Deploy
+  test:
+    name: Test
     runs-on: ubuntu-latest
-    needs: env
-    strategy:
-      matrix: ${{ fromJson(needs.env.outputs.matrix) }}
-      fail-fast: false
-    environment:
-      name: ${{ matrix.env.environment_name }}
-      url: https://${{ steps.url.outputs.stdout }}
     steps:
       - name: Check out
         uses: actions/checkout@v3
@@ -108,19 +101,11 @@ jobs:
           cache: npm
           cache-dependency-path: '**/package-lock.json'
 
-      - name: Audit
-        working-directory: src
-        run: npm audit --audit-level=critical
-
-      - name: Build
+      - name: npm ci
         working-directory: src
         run: npm ci --prefer-offline
 
-      - name: Lint
-        working-directory: src
-        run: npm run lint
-
-      - name: Test
+      - name: npm test
         working-directory: src
         run: npm test
 
@@ -129,6 +114,85 @@ jobs:
         if: env.CODECOV_TOKEN
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node_version }}
+
+      # We don't need to install deps to audit them
+
+      - name: npm audit
+        working-directory: src
+        run: npm audit --audit-level=critical
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: npm ci
+        working-directory: src
+        run: npm ci --prefer-offline
+
+      - name: npm lint
+        working-directory: src
+        run: npm run lint
+
+  hadolint:
+    name: Lint Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Hadolint follows semantic versioning, but doesn't have a @v2 release
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v2.1.0
+        with:
+          dockerfile: src/Dockerfile
+
+  format:
+    name: Terraform Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Terraform Setup
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ env.tf_version }}
+
+      - name: Terraform Format
+        working-directory: terraform-iac
+        run: terraform fmt -check -recursive
+
+  build_and_deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    needs: [env, test, audit, lint, hadolint, format]
+    strategy:
+      matrix: ${{ fromJson(needs.env.outputs.matrix) }}
+      fail-fast: false
+    environment:
+      name: ${{ matrix.env.environment_name }}
+      url: https://${{ steps.url.outputs.stdout }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -175,10 +239,6 @@ jobs:
       - name: Terraform Init
         working-directory: ${{ matrix.env.tf_working_dir }}
         run: terraform init
-
-      - name: Terraform Format
-        working-directory: "./"
-        run: terraform fmt -check -recursive
 
       - name: Terraform Plan
         working-directory: ${{ matrix.env.tf_working_dir }}


### PR DESCRIPTION
I added a `hadolint` job under the assumption that #705 would be accepted.

Here, we take several steps that were part of the one and only job, and split them out into separate jobs so that those steps can be run in parallel. This parallelization should reduce deployment times.

This was a simple first attempt, but there is some further work that we could do:
- [ ] Use [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) to DRY up some code shared between CI and deployments
- [ ] Move Docker build/push into a separate job
  - Potentially complicated because ideally we'd have a single build with multiple pushes for multiple environments
- [ ] Move TF plan analysis to a separate job
  - Potentially complicated because we'd like to re-use the plan, which might get weird with the way `terraform-setup` wraps outputs

Closes #541
Closes #677 