### PR TITLE
Attempt to fix terraform outputs in GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
     environment:
       name: ${{ matrix.env.environment_name }}
-      url: https://${{ steps.url.outputs.stdout }}
+      url: https://${{ steps.terraform-outputs.outputs.url }}
     steps:
       - name: Check out
         uses: actions/checkout@v3
@@ -266,33 +266,22 @@ jobs:
         working-directory: ${{ matrix.env.tf_working_dir }}
         run: terraform apply plan
 
-      - name: Get CD App Name
-        id: cd-app-name
+      - name: Get Terraform Outputs
+        id: terraform-outputs
         working-directory: ${{ matrix.env.tf_working_dir }}
-        run: terraform output -json codedeploy_app_name | tr -d '"'
-
-      - name: Get CD Deployment Group Name
-        id: cd-group-name
-        working-directory: ${{ matrix.env.tf_working_dir }}
-        run: terraform output -json codedeploy_deployment_group_name | tr -d '"'
-
-      - name: Get CD Appspec File
-        id: cd-appspec-file
-        working-directory: ${{ matrix.env.tf_working_dir }}
-        run: terraform output -json codedeploy_appspec_json_file | tr -d '"'
-
-      - name: Get URL
-        id: url
-        working-directory: ${{ matrix.env.tf_working_dir }}
-        run: terraform output -json url | tr -d '"'
+        run: |
+          echo "codedeploy_app_name=$(terraform output -raw codedeploy_app_name)" >> $GITHUB_OUTPUT
+          echo "codedeploy_deployment_group_name=$(terraform output -raw codedeploy_deployment_group_name)" >> $GITHUB_OUTPUT
+          echo "codedeploy_appspec_json_file=$(terraform output -raw codedeploy_appspec_json_file)" >> $GITHUB_OUTPUT
+          echo "url=$(terraform output -raw url)" >> $GITHUB_OUTPUT
 
       - name: CodeDeploy
         id: deploy
         uses: byu-oit/github-action-codedeploy@v1
         with:
-          application-name: ${{ steps.cd-app-name.outputs.stdout }}
-          deployment-group-name: ${{ steps.cd-group-name.outputs.stdout }}
-          appspec-file: ${{ steps.cd-appspec-file.outputs.stdout }}
+          application-name: ${{ steps.terraform-outputs.outputs.codedeploy_app_name }}
+          deployment-group-name: ${{ steps.terraform-outputs.outputs.codedeploy_deployment_group_name }}
+          appspec-file: ${{ steps.terraform-outputs.outputs.codedeploy_appspec_json_file }}
 
       - name: End Standard Change
         uses: byu-oit/github-action-end-standard-change@v1


### PR DESCRIPTION
Based on [this line](https://github.com/byu-oit/hw-fargate-api/actions/runs/3372979745/jobs/5610220822#step:17:42) (and [this code](https://github.com/hashicorp/setup-terraform/blob/main/wrapper/terraform.js#L35), which shouldn't print `"`s unless those were in `stdout.contents`), I think something in setup-terraform's approach to catching stdout is adding the `"`s.

This approach avoids setup-terraform's stdout to output process entirely and allows us to consolidate 4 steps into 1, which looks cleaner in my opinion (and might shave off a second or two, since we don't need to start processes and shells for each step).

I haven't actually tested this new process yet.