### PR TITLE
Try turning off the terraform wrapper now that we're not using it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,6 +235,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ env.tf_version }}
+          terraform_wrapper: false
 
       - name: Terraform Init
         working-directory: ${{ matrix.env.tf_working_dir }}


### PR DESCRIPTION
According to the [docs](https://github.com/hashicorp/setup-terraform), this is what the wrapper does:
> wrap subsequent calls of the terraform binary and expose its STDOUT, STDERR, and exit code as outputs named stdout, stderr, and exitcode respectively. (This can be optionally skipped if subsequent steps in the same job do not need to access the results of Terraform commands.)