### PR TITLE
Use codedeploy action `@v2`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -278,7 +278,7 @@ jobs:
 
       - name: CodeDeploy
         id: deploy
-        uses: byu-oit/github-action-codedeploy@v1
+        uses: byu-oit/github-action-codedeploy@v2
         with:
           application-name: ${{ steps.terraform-outputs.outputs.codedeploy_app_name }}
           deployment-group-name: ${{ steps.terraform-outputs.outputs.codedeploy_deployment_group_name }}


### PR DESCRIPTION
[Release notes](https://github.com/byu-oit/github-action-codedeploy/releases/tag/v2.0.0)

This is a breaking change because of the way it uses Node.js 16, which requires a newer GitHub Actions runner version than before. We're using `ubuntu-latest`, so we should be fine.