### PR TITLE
Update terraform-aws-postman-test-lambda to v5.0.0

### DIFF
--- a/terraform-iac/modules/app/main.tf
+++ b/terraform-iac/modules/app/main.tf
@@ -282,7 +282,7 @@ EOF
 # -----------------------------------------------------------------------------
 
 module "postman_test_lambda" {
-  source   = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v4.0.1"
+  source   = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v5.0.0"
   app_name = "${local.name}-${var.env}"
   postman_collections = [
     {


### PR DESCRIPTION
This should resolve another warning in our Terraform plans. It's only a breaking change because of the way it now requires TF v1.3 and AWS provider v4.