### PR TITLE
Revert "Bump hadolint/hadolint-action from 2.1.0 to 3.0.0"

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -109,7 +109,7 @@ jobs:
 
       # Hadolint follows semantic versioning, but doesn't have a @v2 release
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.0.0
+        uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: src/Dockerfile
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,7 +161,7 @@ jobs:
 
       # Hadolint follows semantic versioning, but doesn't have a @v2 release
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.0.0
+        uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: src/Dockerfile
 


### PR DESCRIPTION
This reverts commit 364cd569ca1bd97a5eba6b3ccb946a6487ba1059.

It appears that hadolint-action@v3.0.0 likely has a regression and isn't actually printing out errors (and creating helpful annotations) any more.

See: [check results for v3.0.0](https://github.com/byu-oit/hw-fargate-api/actions/runs/3492488843/jobs/5846323737) vs [v2.1.0](https://github.com/byu-oit/hw-fargate-api/actions/runs/3492569980/jobs/5846491216).