### PR TITLE
`stg` -> `prd`

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -109,7 +109,7 @@ jobs:
 
       # Hadolint follows semantic versioning, but doesn't have a @v2 release
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.0.0
+        uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: src/Dockerfile
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,7 +161,7 @@ jobs:
 
       # Hadolint follows semantic versioning, but doesn't have a @v2 release
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.0.0
+        uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: src/Dockerfile
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.211.0",
+        "@aws-sdk/client-dynamodb": "^3.212.0",
         "@aws-sdk/client-s3": "^3.212.0",
         "express": "^4.18.2"
       },
@@ -158,11 +158,11 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
+      "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -187,46 +187,46 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.211.0.tgz",
-      "integrity": "sha512-SoinZ+k1TgY/99dUZ2S+FH+sXG3+BaFaSd98if0dygTqIftq9ctaRbDQFss64hdrqu6Qpuvak4XhqaRMaQOr2A==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.212.0.tgz",
+      "integrity": "sha512-BXS+64t1d505PCS9e6qyjg1fghtTxZwzgZt3cYXGkRZO5E4zBX+9NxlEzayU0Wxp1P52260vJDN5dUP77ZOnEg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.211.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.211.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.209.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/client-sts": "3.212.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-node": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.208.0",
+        "@aws-sdk/util-waiter": "3.212.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -298,19 +298,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
-      "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+    "node_modules/@aws-sdk/client-sso": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.212.0.tgz",
       "integrity": "sha512-b9lFI8Uz6YxIzAlS2uq62y5fX097lwcdkiq2N8YN2U7YgHQaKMIFnV8ZqkDdhZi2eUKwhSdUZzQy0tF6en2Ubg==",
@@ -352,7 +340,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
+    "node_modules/@aws-sdk/client-sso-oidc": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.212.0.tgz",
       "integrity": "sha512-Co0AU+y9KEAZUraT36ttFZlmwARsr82q2nQji5E8zg3zlUHtqGvMJqxArudz3iOb2E9WRi75MwAQmLO2xEk45A==",
@@ -394,7 +382,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+    "node_modules/@aws-sdk/client-sts": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.212.0.tgz",
       "integrity": "sha512-Zl8665HT1Do/yfiFEtqEjLkHSkAo5Isg2QU65Kbknj2W2DFj92a1cRvMlHanDLxlpuoryGP9/u1efYZeWeIdlg==",
@@ -440,7 +428,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/config-resolver": {
+    "node_modules/@aws-sdk/config-resolver": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.212.0.tgz",
       "integrity": "sha512-hIP/Izpv6GCsDTnHCd/X9Ro7Mw5le+gr2VbkZHWR0c8+3xZWp8N5S0QnUBogF3Dv2KwPbmHP+bs/vqqo3miUjQ==",
@@ -455,7 +443,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+    "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.212.0.tgz",
       "integrity": "sha512-HNYoqetLqTxwl0Grl4ez8Dx3I3hJfskxH2PTHYI1/iAqrY/gSB2oBOusvBeksbYrScnQM2IGqEcMJ4lzGLOH+w==",
@@ -468,7 +456,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-imds": {
+    "node_modules/@aws-sdk/credential-provider-imds": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.212.0.tgz",
       "integrity": "sha512-Bg7cX2N5pJ//ft3Y8HWtpDSEMMgRTNMaNlIvTlDbAKYp7HBZRWSf9ZJnz2slT7qbyaJyRP5pSJC4XRm83g4leA==",
@@ -483,7 +471,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+    "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.212.0.tgz",
       "integrity": "sha512-H7qRIP8qV7tRrCSJx2p5oQVMJASQWZUmi4l699hDMejmCO/m4pUMQFmWn2FXtZv8gTfzlkmp3wMixD5jnfL7pw==",
@@ -501,7 +489,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+    "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.212.0.tgz",
       "integrity": "sha512-T44hoU3GCYHS+4GDVs7S/v2bBHmmYpnPayQsYXhDElQKXP0cFzQ78F8et4IU5lM94hwK+ISRQPrKaq4p77evkw==",
@@ -521,7 +509,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+    "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.212.0.tgz",
       "integrity": "sha512-bGaVKSm5Tf5VZtlM2V6k+M9nSKzlb14ldCcH0PGGMaK/dqnEJDVSxXPu3fWyomaxbLt7Is3AUMh6L2bq3kuXyA==",
@@ -535,7 +523,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+    "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.212.0.tgz",
       "integrity": "sha512-OGatVUnWLp7PePs2H2RyYmTrwurl0tAfW+LWfVAPgYyvi2RQgTmSK5LJ3pXKxz3TvaSHkCvsT0NWNqdWY+iKWQ==",
@@ -551,711 +539,13 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.212.0.tgz",
       "integrity": "sha512-zPF3KiVT14aeu4cRyEUelAJEAzFp++9ULLigQXhKBbFYaiOZMAHKRASO/WUK1ixYBC+ax4G1rbihLfQimXMtVA==",
       "dependencies": {
         "@aws-sdk/property-provider": "3.212.0",
         "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
-      "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/querystring-builder": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/hash-node": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.212.0.tgz",
-      "integrity": "sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.212.0.tgz",
-      "integrity": "sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.212.0.tgz",
-      "integrity": "sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.212.0.tgz",
-      "integrity": "sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==",
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.212.0",
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/signature-v4": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/url-parser": "3.212.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.212.0.tgz",
-      "integrity": "sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.212.0.tgz",
-      "integrity": "sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz",
-      "integrity": "sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.212.0.tgz",
-      "integrity": "sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/service-error-classification": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-middleware": "3.212.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.212.0.tgz",
-      "integrity": "sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.212.0",
-        "@aws-sdk/property-provider": "3.212.0",
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/signature-v4": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.212.0.tgz",
-      "integrity": "sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.212.0.tgz",
-      "integrity": "sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.212.0",
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/signature-v4": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-middleware": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.212.0.tgz",
-      "integrity": "sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.212.0.tgz",
-      "integrity": "sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz",
-      "integrity": "sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.212.0",
-        "@aws-sdk/shared-ini-file-loader": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
-      "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.212.0",
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/querystring-builder": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/property-provider": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.212.0.tgz",
-      "integrity": "sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
-      "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.212.0.tgz",
-      "integrity": "sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.212.0.tgz",
-      "integrity": "sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.212.0.tgz",
-      "integrity": "sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
-      "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.212.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.212.0.tgz",
-      "integrity": "sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.212.0.tgz",
-      "integrity": "sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.212.0",
-        "@aws-sdk/property-provider": "3.212.0",
-        "@aws-sdk/shared-ini-file-loader": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/url-parser": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.212.0.tgz",
-      "integrity": "sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==",
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.212.0.tgz",
-      "integrity": "sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.212.0.tgz",
-      "integrity": "sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.212.0",
-        "@aws-sdk/credential-provider-imds": "3.212.0",
-        "@aws-sdk/node-config-provider": "3.212.0",
-        "@aws-sdk/property-provider": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.212.0.tgz",
-      "integrity": "sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
-      "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.212.0.tgz",
-      "integrity": "sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz",
-      "integrity": "sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-waiter": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.212.0.tgz",
-      "integrity": "sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
-      "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
-      "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
-      "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.211.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-sts": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-      "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
-      "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.211.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
-      "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.211.0",
-        "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.211.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
-      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
-      "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.211.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.211.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-      "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1285,14 +575,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.212.0.tgz",
@@ -1306,14 +588,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.212.0.tgz",
@@ -1322,14 +596,6 @@
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1347,14 +613,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.212.0.tgz",
@@ -1368,22 +626,14 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
+      "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/querystring-builder": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
@@ -1399,20 +649,12 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/hash-blob-browser/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-      "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.212.0.tgz",
+      "integrity": "sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -1432,20 +674,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-      "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.212.0.tgz",
+      "integrity": "sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -1471,14 +705,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.212.0.tgz",
@@ -1494,11 +720,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/protocol-http": {
+    "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.212.0.tgz",
+      "integrity": "sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==",
       "dependencies": {
+        "@aws-sdk/protocol-http": "3.212.0",
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
@@ -1506,39 +733,18 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-      "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.208.0.tgz",
-      "integrity": "sha512-pVa/cyB6ronfTVAoKUUTFbAPslDPU43DWOKXY/bACC3ys1lFo1CWjz4dLSQARxEEW3iZ1yZTy0zoHXnNrw5CFQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.212.0.tgz",
+      "integrity": "sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==",
       "dependencies": {
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1546,14 +752,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.209.0.tgz",
-      "integrity": "sha512-ZBWYhTBfdc/bUNB1N4jL8ZW7NmKTkdowbZHTlxtXi8ySzzn+qlD+XosIEbXqrVR9sYxSVC3kwsQvADxHzKGixw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.212.0.tgz",
+      "integrity": "sha512-CviyDda9MFM70v0hVQ8Ns6CJrOfOQQe+h0C/f8C4nzj31TmojJFRxnS0MmonZQcHPpyWH2Zt48RQhA9mui+ROQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/config-resolver": "3.212.0",
         "@aws-sdk/endpoint-cache": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1569,26 +775,6 @@
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1609,33 +795,13 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-      "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.212.0.tgz",
+      "integrity": "sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1654,20 +820,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-      "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.212.0.tgz",
+      "integrity": "sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1675,12 +833,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.208.0.tgz",
-      "integrity": "sha512-Dgpf5NEOYXvkQuGcbxvDovTh4HwO4ULJReGko67NJjgdZZyFS1fNykVPncxenRpsN9SJBigswYs3lwPVpqijzA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz",
+      "integrity": "sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1688,14 +846,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.212.0.tgz",
+      "integrity": "sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/service-error-classification": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/service-error-classification": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -1718,10 +876,26 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/protocol-http": {
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
       "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.212.0.tgz",
+      "integrity": "sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.212.0.tgz",
+      "integrity": "sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==",
       "dependencies": {
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
@@ -1730,52 +904,16 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-      "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-      "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.212.0.tgz",
+      "integrity": "sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1794,18 +932,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-      "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.212.0.tgz",
+      "integrity": "sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -1814,12 +944,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-      "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.212.0.tgz",
+      "integrity": "sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1827,13 +957,13 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz",
+      "integrity": "sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1841,14 +971,14 @@
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
+      "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/abort-controller": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/querystring-builder": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1856,11 +986,11 @@
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.212.0.tgz",
+      "integrity": "sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1868,11 +998,11 @@
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1880,11 +1010,11 @@
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+      "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
@@ -1893,11 +1023,11 @@
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.212.0.tgz",
+      "integrity": "sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1905,19 +1035,19 @@
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-      "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.212.0.tgz",
+      "integrity": "sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.212.0.tgz",
+      "integrity": "sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -1925,14 +1055,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
+      "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
@@ -1963,60 +1093,13 @@
         }
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/signature-v4": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
-      "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.212.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-middleware": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
-      "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.212.0.tgz",
+      "integrity": "sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2024,14 +1107,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
-      "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.212.0.tgz",
+      "integrity": "sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.211.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/client-sso-oidc": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2039,20 +1122,20 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.212.0.tgz",
+      "integrity": "sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/querystring-parser": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -2122,12 +1205,12 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.212.0.tgz",
+      "integrity": "sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       },
@@ -2136,15 +1219,15 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.212.0.tgz",
+      "integrity": "sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-imds": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2152,11 +1235,11 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
-      "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.212.0.tgz",
+      "integrity": "sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2186,9 +1269,9 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.208.0.tgz",
-      "integrity": "sha512-oXilrYpXwaPyMw1uNjL1wmR54zeFzIWx2ve1MSMheIYr26deFP3RpMfKkGXwiOvXzZ9pzTcA8shNLhg1frO/zg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
+      "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -2209,51 +1292,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
-      "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/querystring-builder": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
-      "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-stream-node": {
       "version": "3.212.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.212.0.tgz",
@@ -2264,66 +1302,6 @@
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/abort-controller": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
-      "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
-      "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.212.0",
-        "@aws-sdk/protocol-http": "3.212.0",
-        "@aws-sdk/querystring-builder": "3.212.0",
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/protocol-http": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
-      "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.212.0",
-        "@aws-sdk/util-uri-escape": "3.201.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2340,22 +1318,22 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-      "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.212.0.tgz",
+      "integrity": "sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz",
+      "integrity": "sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -2391,12 +1369,12 @@
       }
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
-      "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.212.0.tgz",
+      "integrity": "sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/abort-controller": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -9097,11 +8075,11 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-      "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
+      "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -9123,46 +8101,46 @@
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.211.0.tgz",
-      "integrity": "sha512-SoinZ+k1TgY/99dUZ2S+FH+sXG3+BaFaSd98if0dygTqIftq9ctaRbDQFss64hdrqu6Qpuvak4XhqaRMaQOr2A==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.212.0.tgz",
+      "integrity": "sha512-BXS+64t1d505PCS9e6qyjg1fghtTxZwzgZt3cYXGkRZO5E4zBX+9NxlEzayU0Wxp1P52260vJDN5dUP77ZOnEg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.211.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.211.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.209.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/client-sts": "3.212.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-node": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.208.0",
+        "@aws-sdk/util-waiter": "3.212.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
@@ -9226,701 +8204,123 @@
         "@aws-sdk/xml-builder": "3.201.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
-          "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.212.0.tgz",
-          "integrity": "sha512-b9lFI8Uz6YxIzAlS2uq62y5fX097lwcdkiq2N8YN2U7YgHQaKMIFnV8ZqkDdhZi2eUKwhSdUZzQy0tF6en2Ubg==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.212.0",
-            "@aws-sdk/fetch-http-handler": "3.212.0",
-            "@aws-sdk/hash-node": "3.212.0",
-            "@aws-sdk/invalid-dependency": "3.212.0",
-            "@aws-sdk/middleware-content-length": "3.212.0",
-            "@aws-sdk/middleware-endpoint": "3.212.0",
-            "@aws-sdk/middleware-host-header": "3.212.0",
-            "@aws-sdk/middleware-logger": "3.212.0",
-            "@aws-sdk/middleware-recursion-detection": "3.212.0",
-            "@aws-sdk/middleware-retry": "3.212.0",
-            "@aws-sdk/middleware-serde": "3.212.0",
-            "@aws-sdk/middleware-stack": "3.212.0",
-            "@aws-sdk/middleware-user-agent": "3.212.0",
-            "@aws-sdk/node-config-provider": "3.212.0",
-            "@aws-sdk/node-http-handler": "3.212.0",
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/smithy-client": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/url-parser": "3.212.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.212.0",
-            "@aws-sdk/util-defaults-mode-node": "3.212.0",
-            "@aws-sdk/util-endpoints": "3.212.0",
-            "@aws-sdk/util-user-agent-browser": "3.212.0",
-            "@aws-sdk/util-user-agent-node": "3.212.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.212.0.tgz",
-          "integrity": "sha512-Co0AU+y9KEAZUraT36ttFZlmwARsr82q2nQji5E8zg3zlUHtqGvMJqxArudz3iOb2E9WRi75MwAQmLO2xEk45A==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.212.0",
-            "@aws-sdk/fetch-http-handler": "3.212.0",
-            "@aws-sdk/hash-node": "3.212.0",
-            "@aws-sdk/invalid-dependency": "3.212.0",
-            "@aws-sdk/middleware-content-length": "3.212.0",
-            "@aws-sdk/middleware-endpoint": "3.212.0",
-            "@aws-sdk/middleware-host-header": "3.212.0",
-            "@aws-sdk/middleware-logger": "3.212.0",
-            "@aws-sdk/middleware-recursion-detection": "3.212.0",
-            "@aws-sdk/middleware-retry": "3.212.0",
-            "@aws-sdk/middleware-serde": "3.212.0",
-            "@aws-sdk/middleware-stack": "3.212.0",
-            "@aws-sdk/middleware-user-agent": "3.212.0",
-            "@aws-sdk/node-config-provider": "3.212.0",
-            "@aws-sdk/node-http-handler": "3.212.0",
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/smithy-client": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/url-parser": "3.212.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.212.0",
-            "@aws-sdk/util-defaults-mode-node": "3.212.0",
-            "@aws-sdk/util-endpoints": "3.212.0",
-            "@aws-sdk/util-user-agent-browser": "3.212.0",
-            "@aws-sdk/util-user-agent-node": "3.212.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.212.0.tgz",
-          "integrity": "sha512-Zl8665HT1Do/yfiFEtqEjLkHSkAo5Isg2QU65Kbknj2W2DFj92a1cRvMlHanDLxlpuoryGP9/u1efYZeWeIdlg==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.212.0",
-            "@aws-sdk/credential-provider-node": "3.212.0",
-            "@aws-sdk/fetch-http-handler": "3.212.0",
-            "@aws-sdk/hash-node": "3.212.0",
-            "@aws-sdk/invalid-dependency": "3.212.0",
-            "@aws-sdk/middleware-content-length": "3.212.0",
-            "@aws-sdk/middleware-endpoint": "3.212.0",
-            "@aws-sdk/middleware-host-header": "3.212.0",
-            "@aws-sdk/middleware-logger": "3.212.0",
-            "@aws-sdk/middleware-recursion-detection": "3.212.0",
-            "@aws-sdk/middleware-retry": "3.212.0",
-            "@aws-sdk/middleware-sdk-sts": "3.212.0",
-            "@aws-sdk/middleware-serde": "3.212.0",
-            "@aws-sdk/middleware-signing": "3.212.0",
-            "@aws-sdk/middleware-stack": "3.212.0",
-            "@aws-sdk/middleware-user-agent": "3.212.0",
-            "@aws-sdk/node-config-provider": "3.212.0",
-            "@aws-sdk/node-http-handler": "3.212.0",
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/smithy-client": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/url-parser": "3.212.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.212.0",
-            "@aws-sdk/util-defaults-mode-node": "3.212.0",
-            "@aws-sdk/util-endpoints": "3.212.0",
-            "@aws-sdk/util-user-agent-browser": "3.212.0",
-            "@aws-sdk/util-user-agent-node": "3.212.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.212.0.tgz",
-          "integrity": "sha512-hIP/Izpv6GCsDTnHCd/X9Ro7Mw5le+gr2VbkZHWR0c8+3xZWp8N5S0QnUBogF3Dv2KwPbmHP+bs/vqqo3miUjQ==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.212.0.tgz",
-          "integrity": "sha512-HNYoqetLqTxwl0Grl4ez8Dx3I3hJfskxH2PTHYI1/iAqrY/gSB2oBOusvBeksbYrScnQM2IGqEcMJ4lzGLOH+w==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.212.0.tgz",
-          "integrity": "sha512-Bg7cX2N5pJ//ft3Y8HWtpDSEMMgRTNMaNlIvTlDbAKYp7HBZRWSf9ZJnz2slT7qbyaJyRP5pSJC4XRm83g4leA==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.212.0",
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/url-parser": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.212.0.tgz",
-          "integrity": "sha512-H7qRIP8qV7tRrCSJx2p5oQVMJASQWZUmi4l699hDMejmCO/m4pUMQFmWn2FXtZv8gTfzlkmp3wMixD5jnfL7pw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.212.0",
-            "@aws-sdk/credential-provider-imds": "3.212.0",
-            "@aws-sdk/credential-provider-sso": "3.212.0",
-            "@aws-sdk/credential-provider-web-identity": "3.212.0",
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/shared-ini-file-loader": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.212.0.tgz",
-          "integrity": "sha512-T44hoU3GCYHS+4GDVs7S/v2bBHmmYpnPayQsYXhDElQKXP0cFzQ78F8et4IU5lM94hwK+ISRQPrKaq4p77evkw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.212.0",
-            "@aws-sdk/credential-provider-imds": "3.212.0",
-            "@aws-sdk/credential-provider-ini": "3.212.0",
-            "@aws-sdk/credential-provider-process": "3.212.0",
-            "@aws-sdk/credential-provider-sso": "3.212.0",
-            "@aws-sdk/credential-provider-web-identity": "3.212.0",
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/shared-ini-file-loader": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.212.0.tgz",
-          "integrity": "sha512-bGaVKSm5Tf5VZtlM2V6k+M9nSKzlb14ldCcH0PGGMaK/dqnEJDVSxXPu3fWyomaxbLt7Is3AUMh6L2bq3kuXyA==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/shared-ini-file-loader": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.212.0.tgz",
-          "integrity": "sha512-OGatVUnWLp7PePs2H2RyYmTrwurl0tAfW+LWfVAPgYyvi2RQgTmSK5LJ3pXKxz3TvaSHkCvsT0NWNqdWY+iKWQ==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.212.0",
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/shared-ini-file-loader": "3.212.0",
-            "@aws-sdk/token-providers": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.212.0.tgz",
-          "integrity": "sha512-zPF3KiVT14aeu4cRyEUelAJEAzFp++9ULLigQXhKBbFYaiOZMAHKRASO/WUK1ixYBC+ax4G1rbihLfQimXMtVA==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
-          "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/querystring-builder": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/hash-node": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.212.0.tgz",
-          "integrity": "sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-buffer-from": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/invalid-dependency": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.212.0.tgz",
-          "integrity": "sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-content-length": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.212.0.tgz",
-          "integrity": "sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-endpoint": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.212.0.tgz",
-          "integrity": "sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==",
-          "requires": {
-            "@aws-sdk/middleware-serde": "3.212.0",
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/signature-v4": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/url-parser": "3.212.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.212.0.tgz",
-          "integrity": "sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.212.0.tgz",
-          "integrity": "sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz",
-          "integrity": "sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.212.0.tgz",
-          "integrity": "sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/service-error-classification": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-middleware": "3.212.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.212.0.tgz",
-          "integrity": "sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==",
-          "requires": {
-            "@aws-sdk/middleware-signing": "3.212.0",
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/signature-v4": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-serde": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.212.0.tgz",
-          "integrity": "sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-signing": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.212.0.tgz",
-          "integrity": "sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/signature-v4": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-middleware": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-stack": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.212.0.tgz",
-          "integrity": "sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.212.0.tgz",
-          "integrity": "sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz",
-          "integrity": "sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/shared-ini-file-loader": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
-          "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.212.0",
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/querystring-builder": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/property-provider": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.212.0.tgz",
-          "integrity": "sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
-          "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-parser": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.212.0.tgz",
-          "integrity": "sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/service-error-classification": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.212.0.tgz",
-          "integrity": "sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ=="
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.212.0.tgz",
-          "integrity": "sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
-          "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.212.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.212.0.tgz",
-          "integrity": "sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.212.0.tgz",
-          "integrity": "sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==",
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.212.0",
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/shared-ini-file-loader": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        },
-        "@aws-sdk/url-parser": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.212.0.tgz",
-          "integrity": "sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==",
-          "requires": {
-            "@aws-sdk/querystring-parser": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.212.0.tgz",
-          "integrity": "sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.212.0.tgz",
-          "integrity": "sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==",
-          "requires": {
-            "@aws-sdk/config-resolver": "3.212.0",
-            "@aws-sdk/credential-provider-imds": "3.212.0",
-            "@aws-sdk/node-config-provider": "3.212.0",
-            "@aws-sdk/property-provider": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.212.0.tgz",
-          "integrity": "sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
-          "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.212.0.tgz",
-          "integrity": "sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz",
-          "integrity": "sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-waiter": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.212.0.tgz",
-          "integrity": "sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
-      "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.212.0.tgz",
+      "integrity": "sha512-b9lFI8Uz6YxIzAlS2uq62y5fX097lwcdkiq2N8YN2U7YgHQaKMIFnV8ZqkDdhZi2eUKwhSdUZzQy0tF6en2Ubg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
-      "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.212.0.tgz",
+      "integrity": "sha512-Co0AU+y9KEAZUraT36ttFZlmwARsr82q2nQji5E8zg3zlUHtqGvMJqxArudz3iOb2E9WRi75MwAQmLO2xEk45A==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
-      "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.212.0.tgz",
+      "integrity": "sha512-Zl8665HT1Do/yfiFEtqEjLkHSkAo5Isg2QU65Kbknj2W2DFj92a1cRvMlHanDLxlpuoryGP9/u1efYZeWeIdlg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.211.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-sts": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-node": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-sdk-sts": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "fast-xml-parser": "4.0.11",
@@ -9928,102 +8328,102 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.212.0.tgz",
+      "integrity": "sha512-hIP/Izpv6GCsDTnHCd/X9Ro7Mw5le+gr2VbkZHWR0c8+3xZWp8N5S0QnUBogF3Dv2KwPbmHP+bs/vqqo3miUjQ==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-      "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.212.0.tgz",
+      "integrity": "sha512-HNYoqetLqTxwl0Grl4ez8Dx3I3hJfskxH2PTHYI1/iAqrY/gSB2oBOusvBeksbYrScnQM2IGqEcMJ4lzGLOH+w==",
       "requires": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.212.0.tgz",
+      "integrity": "sha512-Bg7cX2N5pJ//ft3Y8HWtpDSEMMgRTNMaNlIvTlDbAKYp7HBZRWSf9ZJnz2slT7qbyaJyRP5pSJC4XRm83g4leA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
-      "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.212.0.tgz",
+      "integrity": "sha512-H7qRIP8qV7tRrCSJx2p5oQVMJASQWZUmi4l699hDMejmCO/m4pUMQFmWn2FXtZv8gTfzlkmp3wMixD5jnfL7pw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.211.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/credential-provider-env": "3.212.0",
+        "@aws-sdk/credential-provider-imds": "3.212.0",
+        "@aws-sdk/credential-provider-sso": "3.212.0",
+        "@aws-sdk/credential-provider-web-identity": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
-      "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.212.0.tgz",
+      "integrity": "sha512-T44hoU3GCYHS+4GDVs7S/v2bBHmmYpnPayQsYXhDElQKXP0cFzQ78F8et4IU5lM94hwK+ISRQPrKaq4p77evkw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.211.0",
-        "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.211.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/credential-provider-env": "3.212.0",
+        "@aws-sdk/credential-provider-imds": "3.212.0",
+        "@aws-sdk/credential-provider-ini": "3.212.0",
+        "@aws-sdk/credential-provider-process": "3.212.0",
+        "@aws-sdk/credential-provider-sso": "3.212.0",
+        "@aws-sdk/credential-provider-web-identity": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
-      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.212.0.tgz",
+      "integrity": "sha512-bGaVKSm5Tf5VZtlM2V6k+M9nSKzlb14ldCcH0PGGMaK/dqnEJDVSxXPu3fWyomaxbLt7Is3AUMh6L2bq3kuXyA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
-      "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.212.0.tgz",
+      "integrity": "sha512-OGatVUnWLp7PePs2H2RyYmTrwurl0tAfW+LWfVAPgYyvi2RQgTmSK5LJ3pXKxz3TvaSHkCvsT0NWNqdWY+iKWQ==",
       "requires": {
-        "@aws-sdk/client-sso": "3.211.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.211.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/client-sso": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/token-providers": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-      "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.212.0.tgz",
+      "integrity": "sha512-zPF3KiVT14aeu4cRyEUelAJEAzFp++9ULLigQXhKBbFYaiOZMAHKRASO/WUK1ixYBC+ax4G1rbihLfQimXMtVA==",
       "requires": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10045,13 +8445,6 @@
         "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
@@ -10062,13 +8455,6 @@
         "@aws-sdk/eventstream-serde-universal": "3.212.0",
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
@@ -10078,13 +8464,6 @@
       "requires": {
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/eventstream-serde-node": {
@@ -10095,13 +8474,6 @@
         "@aws-sdk/eventstream-serde-universal": "3.212.0",
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
@@ -10112,23 +8484,16 @@
         "@aws-sdk/eventstream-codec": "3.212.0",
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-      "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
+      "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/querystring-builder": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
@@ -10142,21 +8507,14 @@
         "@aws-sdk/chunked-blob-reader-native": "3.208.0",
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-      "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.212.0.tgz",
+      "integrity": "sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       }
@@ -10168,21 +8526,14 @@
       "requires": {
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-      "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.212.0.tgz",
+      "integrity": "sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10203,13 +8554,6 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
@@ -10222,58 +8566,42 @@
         "@aws-sdk/util-arn-parser": "3.208.0",
         "@aws-sdk/util-config-provider": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-      "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.212.0.tgz",
+      "integrity": "sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-endpoint": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.208.0.tgz",
-      "integrity": "sha512-pVa/cyB6ronfTVAoKUUTFbAPslDPU43DWOKXY/bACC3ys1lFo1CWjz4dLSQARxEEW3iZ1yZTy0zoHXnNrw5CFQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.212.0.tgz",
+      "integrity": "sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==",
       "requires": {
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.209.0.tgz",
-      "integrity": "sha512-ZBWYhTBfdc/bUNB1N4jL8ZW7NmKTkdowbZHTlxtXi8ySzzn+qlD+XosIEbXqrVR9sYxSVC3kwsQvADxHzKGixw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.212.0.tgz",
+      "integrity": "sha512-CviyDda9MFM70v0hVQ8Ns6CJrOfOQQe+h0C/f8C4nzj31TmojJFRxnS0MmonZQcHPpyWH2Zt48RQhA9mui+ROQ==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/config-resolver": "3.212.0",
         "@aws-sdk/endpoint-cache": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10285,22 +8613,6 @@
         "@aws-sdk/protocol-http": "3.212.0",
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
@@ -10314,31 +8626,15 @@
         "@aws-sdk/protocol-http": "3.212.0",
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-      "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.212.0.tgz",
+      "integrity": "sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10349,43 +8645,36 @@
       "requires": {
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-      "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.212.0.tgz",
+      "integrity": "sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.208.0.tgz",
-      "integrity": "sha512-Dgpf5NEOYXvkQuGcbxvDovTh4HwO4ULJReGko67NJjgdZZyFS1fNykVPncxenRpsN9SJBigswYs3lwPVpqijzA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz",
+      "integrity": "sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.212.0.tgz",
+      "integrity": "sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/service-error-classification": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/service-error-classification": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
@@ -10400,56 +8689,40 @@
         "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-      "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.212.0.tgz",
+      "integrity": "sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-      "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.212.0.tgz",
+      "integrity": "sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-      "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.212.0.tgz",
+      "integrity": "sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10460,116 +8733,109 @@
       "requires": {
         "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-      "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.212.0.tgz",
+      "integrity": "sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-      "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.212.0.tgz",
+      "integrity": "sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz",
+      "integrity": "sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==",
       "requires": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-      "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
+      "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/querystring-builder": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/abort-controller": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/querystring-builder": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-      "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.212.0.tgz",
+      "integrity": "sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-      "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-      "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+      "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-      "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.212.0.tgz",
+      "integrity": "sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-      "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw=="
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.212.0.tgz",
+      "integrity": "sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.212.0.tgz",
+      "integrity": "sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-      "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
+      "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
       "requires": {
         "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
-        "@aws-sdk/util-middleware": "3.208.0",
+        "@aws-sdk/util-middleware": "3.212.0",
         "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       }
@@ -10584,79 +8850,42 @@
         "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/protocol-http": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/signature-v4": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
-          "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
-          "requires": {
-            "@aws-sdk/is-array-buffer": "3.201.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-hex-encoding": "3.201.0",
-            "@aws-sdk/util-middleware": "3.212.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        },
-        "@aws-sdk/util-middleware": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
-          "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
-          "requires": {
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.212.0.tgz",
+      "integrity": "sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
-      "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.212.0.tgz",
+      "integrity": "sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.211.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/client-sso-oidc": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-      "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
     },
     "@aws-sdk/url-parser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-      "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.212.0.tgz",
+      "integrity": "sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/querystring-parser": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10711,35 +8940,35 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.212.0.tgz",
+      "integrity": "sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==",
       "requires": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.212.0.tgz",
+      "integrity": "sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-imds": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
-      "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.212.0.tgz",
+      "integrity": "sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10760,9 +8989,9 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.208.0.tgz",
-      "integrity": "sha512-oXilrYpXwaPyMw1uNjL1wmR54zeFzIWx2ve1MSMheIYr26deFP3RpMfKkGXwiOvXzZ9pzTcA8shNLhg1frO/zg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
+      "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10778,44 +9007,6 @@
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/fetch-http-handler": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
-          "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/querystring-builder": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
-          "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/util-stream-node": {
@@ -10827,53 +9018,6 @@
         "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/abort-controller": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
-          "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/node-http-handler": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
-          "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
-          "requires": {
-            "@aws-sdk/abort-controller": "3.212.0",
-            "@aws-sdk/protocol-http": "3.212.0",
-            "@aws-sdk/querystring-builder": "3.212.0",
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/protocol-http": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
-          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/querystring-builder": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
-          "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
-          "requires": {
-            "@aws-sdk/types": "3.212.0",
-            "@aws-sdk/util-uri-escape": "3.201.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.212.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
-          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
-        }
       }
     },
     "@aws-sdk/util-uri-escape": {
@@ -10885,22 +9029,22 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-      "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.212.0.tgz",
+      "integrity": "sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz",
+      "integrity": "sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },
@@ -10922,12 +9066,12 @@
       }
     },
     "@aws-sdk/util-waiter": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
-      "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.212.0.tgz",
+      "integrity": "sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/abort-controller": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       }
     },

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.211.0",
-        "@aws-sdk/client-s3": "^3.210.0",
+        "@aws-sdk/client-s3": "^3.211.0",
         "express": "^4.18.2"
       },
       "devDependencies": {
@@ -234,7 +234,71 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.211.0.tgz",
+      "integrity": "sha512-Wk7bqhhdMtys/dd97ap0GMfJcGzlYrlWsGzK5uNF+TqvOcpZ4NIk7Ui0+NCtSfrM8CajfQRamwPKs0N/8sFIiQ==",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.211.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
+        "@aws-sdk/eventstream-serde-browser": "3.208.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
+        "@aws-sdk/eventstream-serde-node": "3.208.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-blob-browser": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/hash-stream-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/md5-js": "3.208.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-expect-continue": "3.208.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-location-constraint": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-s3": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/middleware-ssec": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/signature-v4-multi-region": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-stream-browser": "3.208.0",
+        "@aws-sdk/util-stream-node": "3.208.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.208.0",
+        "@aws-sdk/xml-builder": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
       "version": "3.211.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
       "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
@@ -276,7 +340,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso-oidc": {
+    "node_modules/@aws-sdk/client-sso-oidc": {
       "version": "3.211.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
       "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
@@ -318,7 +382,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+    "node_modules/@aws-sdk/client-sts": {
       "version": "3.211.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
       "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
@@ -353,281 +417,6 @@
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
         "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
-      "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.211.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
-      "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.211.0",
-        "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.211.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
-      "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.211.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.211.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
-      "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.211.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
-      "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.210.0.tgz",
-      "integrity": "sha512-ZOadr6Bt5PKsHS7zH5VwgvdPrqNkxYJ0fiPa9tM3jc4oyT9U56DkWGgd6UW31EGnySNVuBUPOiu9MjCc7gfFQA==",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "2.0.0",
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.210.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.210.0",
-        "@aws-sdk/eventstream-serde-browser": "3.208.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
-        "@aws-sdk/eventstream-serde-node": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-blob-browser": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/hash-stream-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/md5-js": "3.208.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-expect-continue": "3.208.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-location-constraint": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-s3": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-ssec": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4-multi-region": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
-        "@aws-sdk/util-stream-browser": "3.208.0",
-        "@aws-sdk/util-stream-node": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.208.0",
-        "@aws-sdk/xml-builder": "3.201.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.210.0.tgz",
-      "integrity": "sha512-3ZWZF7Vo4d/OhsRZegwGperFUnshkQxz+iBr9Vs+OyR44oX3uMyMUyefSk+78UOc/wK0WPt3zXfEWrV4FkkhAg==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.210.0.tgz",
-      "integrity": "sha512-OAVb7kP7FsfGrnMacdLqt2Tsy/ihp66CaBzxfJiGPg3o1T81nVKLiHGCdEQWRbuFS3jy+C8sJ51kv7dPQYpegQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.210.0.tgz",
-      "integrity": "sha512-wbadDc0WS6uy/ITC7w4Ntltloun4sPcgu2YtMb2qH+FjsNNEaZ6XpeaOJYSiBjpLeVy3ipalV69L3fi/LmKDjg==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.210.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-sts": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -683,13 +472,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.210.0.tgz",
-      "integrity": "sha512-vEI7FzV2Zs8pfNtEVPi5eSx+T0V6lIT8a6LlRFnvQeJOliNtreN/li/QA8CIqAmH4ChPmZbYYKvc/Bb/fRf/WQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
+      "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.208.0",
         "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.210.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
@@ -701,15 +490,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.210.0.tgz",
-      "integrity": "sha512-J/FtblqkB9SJmZAYe7OS1+gtNom7FCnQkky8crGTuIUCDJBt9VpvRn0juFIfHtkPln56q7myDieH6GNoD+l/sw==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
+      "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.208.0",
         "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.210.0",
+        "@aws-sdk/credential-provider-ini": "3.211.0",
         "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.210.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
@@ -735,14 +524,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.210.0.tgz",
-      "integrity": "sha512-76+fw8ES6bGXUMpbAp0yVX0jEf0mPpZHDfluvwbJlpc2VTsx5/GPAkWoEfAlLPC7aFDOXYhvlo9hrs8ebZOeNw==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
+      "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.210.0",
+        "@aws-sdk/client-sso": "3.211.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.210.0",
+        "@aws-sdk/token-providers": "3.211.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -1318,11 +1107,11 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.210.0.tgz",
-      "integrity": "sha512-UHoj9eKHQZtEII2U+xcflH8clpLMSDXqY1BDlXBjqeztwMcID6FdT19Agf4rofu4n3Qy3gyxRbcYMfp2AOmeaQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
+      "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.210.0",
+        "@aws-sdk/client-sso-oidc": "3.211.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
@@ -1446,9 +1235,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.210.0.tgz",
-      "integrity": "sha512-OVDTj7QlXo3WvGwSIyKkg3oYaaXOq+mjYdSLu9h0BC8Ul4SnW5iKS9wIy2AhYQKIpgML9ucueUJrCZS3W23I2A==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
+      "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
       "dependencies": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -8354,208 +8143,19 @@
         "@aws-sdk/util-waiter": "3.208.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.211.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
-          "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.211.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.211.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
-          "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.211.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.211.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
-          "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/credential-provider-node": "3.211.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-sdk-sts": "3.208.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.211.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.211.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
-          "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/credential-provider-sso": "3.211.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.211.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
-          "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/credential-provider-ini": "3.211.0",
-            "@aws-sdk/credential-provider-process": "3.209.0",
-            "@aws-sdk/credential-provider-sso": "3.211.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.211.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
-          "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.211.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/token-providers": "3.211.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.211.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
-          "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.211.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.211.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
-          "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.210.0.tgz",
-      "integrity": "sha512-ZOadr6Bt5PKsHS7zH5VwgvdPrqNkxYJ0fiPa9tM3jc4oyT9U56DkWGgd6UW31EGnySNVuBUPOiu9MjCc7gfFQA==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.211.0.tgz",
+      "integrity": "sha512-Wk7bqhhdMtys/dd97ap0GMfJcGzlYrlWsGzK5uNF+TqvOcpZ4NIk7Ui0+NCtSfrM8CajfQRamwPKs0N/8sFIiQ==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.210.0",
+        "@aws-sdk/client-sts": "3.211.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.210.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/eventstream-serde-browser": "3.208.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
         "@aws-sdk/eventstream-serde-node": "3.208.0",
@@ -8593,7 +8193,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-stream-browser": "3.208.0",
         "@aws-sdk/util-stream-node": "3.208.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
@@ -8607,9 +8207,9 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.210.0.tgz",
-      "integrity": "sha512-3ZWZF7Vo4d/OhsRZegwGperFUnshkQxz+iBr9Vs+OyR44oX3uMyMUyefSk+78UOc/wK0WPt3zXfEWrV4FkkhAg==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
+      "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -8637,7 +8237,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -8646,9 +8246,9 @@
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.210.0.tgz",
-      "integrity": "sha512-OAVb7kP7FsfGrnMacdLqt2Tsy/ihp66CaBzxfJiGPg3o1T81nVKLiHGCdEQWRbuFS3jy+C8sJ51kv7dPQYpegQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
+      "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -8676,7 +8276,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -8685,14 +8285,14 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.210.0.tgz",
-      "integrity": "sha512-wbadDc0WS6uy/ITC7w4Ntltloun4sPcgu2YtMb2qH+FjsNNEaZ6XpeaOJYSiBjpLeVy3ipalV69L3fi/LmKDjg==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
+      "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.210.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -8718,7 +8318,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -8762,13 +8362,13 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.210.0.tgz",
-      "integrity": "sha512-vEI7FzV2Zs8pfNtEVPi5eSx+T0V6lIT8a6LlRFnvQeJOliNtreN/li/QA8CIqAmH4ChPmZbYYKvc/Bb/fRf/WQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
+      "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.208.0",
         "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.210.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
@@ -8777,15 +8377,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.210.0.tgz",
-      "integrity": "sha512-J/FtblqkB9SJmZAYe7OS1+gtNom7FCnQkky8crGTuIUCDJBt9VpvRn0juFIfHtkPln56q7myDieH6GNoD+l/sw==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
+      "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.208.0",
         "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.210.0",
+        "@aws-sdk/credential-provider-ini": "3.211.0",
         "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.210.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
@@ -8805,14 +8405,14 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.210.0.tgz",
-      "integrity": "sha512-76+fw8ES6bGXUMpbAp0yVX0jEf0mPpZHDfluvwbJlpc2VTsx5/GPAkWoEfAlLPC7aFDOXYhvlo9hrs8ebZOeNw==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
+      "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
       "requires": {
-        "@aws-sdk/client-sso": "3.210.0",
+        "@aws-sdk/client-sso": "3.211.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.210.0",
+        "@aws-sdk/token-providers": "3.211.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }
@@ -9263,11 +8863,11 @@
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.210.0.tgz",
-      "integrity": "sha512-UHoj9eKHQZtEII2U+xcflH8clpLMSDXqY1BDlXBjqeztwMcID6FdT19Agf4rofu4n3Qy3gyxRbcYMfp2AOmeaQ==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
+      "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.210.0",
+        "@aws-sdk/client-sso-oidc": "3.211.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
@@ -9364,9 +8964,9 @@
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.210.0.tgz",
-      "integrity": "sha512-OVDTj7QlXo3WvGwSIyKkg3oYaaXOq+mjYdSLu9h0BC8Ul4SnW5iKS9wIy2AhYQKIpgML9ucueUJrCZS3W23I2A==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
+      "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.209.0",
+        "@aws-sdk/client-dynamodb": "^3.210.0",
         "@aws-sdk/client-s3": "^3.209.0",
         "express": "^4.18.2"
       },
@@ -187,15 +187,15 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.209.0.tgz",
-      "integrity": "sha512-m+04jiyNzBLETphijusiyxXRklf9R58SDXQKKwP7LoDliU6ko76XjAwKVZsVwvM98xPMp8LEDUjoTCw+TdxMnw==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.210.0.tgz",
+      "integrity": "sha512-umSGa1ShdeqifnxAx7jEZryd0MgSQMZXhNc0jfwONzDbRaGaOEQLuL9dRARfT7vtUWjV4wpxv+PBfQjtJHICog==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/client-sts": "3.210.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.210.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -221,7 +221,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -229,6 +229,217 @@
         "@aws-sdk/util-waiter": "3.208.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.210.0.tgz",
+      "integrity": "sha512-3ZWZF7Vo4d/OhsRZegwGperFUnshkQxz+iBr9Vs+OyR44oX3uMyMUyefSk+78UOc/wK0WPt3zXfEWrV4FkkhAg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.210.0.tgz",
+      "integrity": "sha512-OAVb7kP7FsfGrnMacdLqt2Tsy/ihp66CaBzxfJiGPg3o1T81nVKLiHGCdEQWRbuFS3jy+C8sJ51kv7dPQYpegQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.210.0.tgz",
+      "integrity": "sha512-wbadDc0WS6uy/ITC7w4Ntltloun4sPcgu2YtMb2qH+FjsNNEaZ6XpeaOJYSiBjpLeVy3ipalV69L3fi/LmKDjg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.210.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-sts": "3.208.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.210.0.tgz",
+      "integrity": "sha512-vEI7FzV2Zs8pfNtEVPi5eSx+T0V6lIT8a6LlRFnvQeJOliNtreN/li/QA8CIqAmH4ChPmZbYYKvc/Bb/fRf/WQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.210.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.210.0.tgz",
+      "integrity": "sha512-J/FtblqkB9SJmZAYe7OS1+gtNom7FCnQkky8crGTuIUCDJBt9VpvRn0juFIfHtkPln56q7myDieH6GNoD+l/sw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.210.0",
+        "@aws-sdk/credential-provider-process": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.210.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.210.0.tgz",
+      "integrity": "sha512-76+fw8ES6bGXUMpbAp0yVX0jEf0mPpZHDfluvwbJlpc2VTsx5/GPAkWoEfAlLPC7aFDOXYhvlo9hrs8ebZOeNw==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.210.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/token-providers": "3.210.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.210.0.tgz",
+      "integrity": "sha512-UHoj9eKHQZtEII2U+xcflH8clpLMSDXqY1BDlXBjqeztwMcID6FdT19Agf4rofu4n3Qy3gyxRbcYMfp2AOmeaQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.210.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.210.0.tgz",
+      "integrity": "sha512-OVDTj7QlXo3WvGwSIyKkg3oYaaXOq+mjYdSLu9h0BC8Ul4SnW5iKS9wIy2AhYQKIpgML9ucueUJrCZS3W23I2A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -8101,15 +8312,15 @@
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.209.0.tgz",
-      "integrity": "sha512-m+04jiyNzBLETphijusiyxXRklf9R58SDXQKKwP7LoDliU6ko76XjAwKVZsVwvM98xPMp8LEDUjoTCw+TdxMnw==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.210.0.tgz",
+      "integrity": "sha512-umSGa1ShdeqifnxAx7jEZryd0MgSQMZXhNc0jfwONzDbRaGaOEQLuL9dRARfT7vtUWjV4wpxv+PBfQjtJHICog==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/client-sts": "3.210.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.210.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -8135,7 +8346,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -8143,6 +8354,195 @@
         "@aws-sdk/util-waiter": "3.208.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.210.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.210.0.tgz",
+          "integrity": "sha512-3ZWZF7Vo4d/OhsRZegwGperFUnshkQxz+iBr9Vs+OyR44oX3uMyMUyefSk+78UOc/wK0WPt3zXfEWrV4FkkhAg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/fetch-http-handler": "3.208.0",
+            "@aws-sdk/hash-node": "3.208.0",
+            "@aws-sdk/invalid-dependency": "3.208.0",
+            "@aws-sdk/middleware-content-length": "3.208.0",
+            "@aws-sdk/middleware-endpoint": "3.208.0",
+            "@aws-sdk/middleware-host-header": "3.208.0",
+            "@aws-sdk/middleware-logger": "3.208.0",
+            "@aws-sdk/middleware-recursion-detection": "3.208.0",
+            "@aws-sdk/middleware-retry": "3.209.0",
+            "@aws-sdk/middleware-serde": "3.208.0",
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/middleware-user-agent": "3.208.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/node-http-handler": "3.208.0",
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/smithy-client": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+            "@aws-sdk/util-defaults-mode-node": "3.209.0",
+            "@aws-sdk/util-endpoints": "3.210.0",
+            "@aws-sdk/util-user-agent-browser": "3.208.0",
+            "@aws-sdk/util-user-agent-node": "3.209.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.210.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.210.0.tgz",
+          "integrity": "sha512-OAVb7kP7FsfGrnMacdLqt2Tsy/ihp66CaBzxfJiGPg3o1T81nVKLiHGCdEQWRbuFS3jy+C8sJ51kv7dPQYpegQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/fetch-http-handler": "3.208.0",
+            "@aws-sdk/hash-node": "3.208.0",
+            "@aws-sdk/invalid-dependency": "3.208.0",
+            "@aws-sdk/middleware-content-length": "3.208.0",
+            "@aws-sdk/middleware-endpoint": "3.208.0",
+            "@aws-sdk/middleware-host-header": "3.208.0",
+            "@aws-sdk/middleware-logger": "3.208.0",
+            "@aws-sdk/middleware-recursion-detection": "3.208.0",
+            "@aws-sdk/middleware-retry": "3.209.0",
+            "@aws-sdk/middleware-serde": "3.208.0",
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/middleware-user-agent": "3.208.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/node-http-handler": "3.208.0",
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/smithy-client": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+            "@aws-sdk/util-defaults-mode-node": "3.209.0",
+            "@aws-sdk/util-endpoints": "3.210.0",
+            "@aws-sdk/util-user-agent-browser": "3.208.0",
+            "@aws-sdk/util-user-agent-node": "3.209.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.210.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.210.0.tgz",
+          "integrity": "sha512-wbadDc0WS6uy/ITC7w4Ntltloun4sPcgu2YtMb2qH+FjsNNEaZ6XpeaOJYSiBjpLeVy3ipalV69L3fi/LmKDjg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/credential-provider-node": "3.210.0",
+            "@aws-sdk/fetch-http-handler": "3.208.0",
+            "@aws-sdk/hash-node": "3.208.0",
+            "@aws-sdk/invalid-dependency": "3.208.0",
+            "@aws-sdk/middleware-content-length": "3.208.0",
+            "@aws-sdk/middleware-endpoint": "3.208.0",
+            "@aws-sdk/middleware-host-header": "3.208.0",
+            "@aws-sdk/middleware-logger": "3.208.0",
+            "@aws-sdk/middleware-recursion-detection": "3.208.0",
+            "@aws-sdk/middleware-retry": "3.209.0",
+            "@aws-sdk/middleware-sdk-sts": "3.208.0",
+            "@aws-sdk/middleware-serde": "3.208.0",
+            "@aws-sdk/middleware-signing": "3.208.0",
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/middleware-user-agent": "3.208.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/node-http-handler": "3.208.0",
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/smithy-client": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+            "@aws-sdk/util-defaults-mode-node": "3.209.0",
+            "@aws-sdk/util-endpoints": "3.210.0",
+            "@aws-sdk/util-user-agent-browser": "3.208.0",
+            "@aws-sdk/util-user-agent-node": "3.209.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.210.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.210.0.tgz",
+          "integrity": "sha512-vEI7FzV2Zs8pfNtEVPi5eSx+T0V6lIT8a6LlRFnvQeJOliNtreN/li/QA8CIqAmH4ChPmZbYYKvc/Bb/fRf/WQ==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.208.0",
+            "@aws-sdk/credential-provider-imds": "3.209.0",
+            "@aws-sdk/credential-provider-sso": "3.210.0",
+            "@aws-sdk/credential-provider-web-identity": "3.208.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.210.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.210.0.tgz",
+          "integrity": "sha512-J/FtblqkB9SJmZAYe7OS1+gtNom7FCnQkky8crGTuIUCDJBt9VpvRn0juFIfHtkPln56q7myDieH6GNoD+l/sw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.208.0",
+            "@aws-sdk/credential-provider-imds": "3.209.0",
+            "@aws-sdk/credential-provider-ini": "3.210.0",
+            "@aws-sdk/credential-provider-process": "3.209.0",
+            "@aws-sdk/credential-provider-sso": "3.210.0",
+            "@aws-sdk/credential-provider-web-identity": "3.208.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.210.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.210.0.tgz",
+          "integrity": "sha512-76+fw8ES6bGXUMpbAp0yVX0jEf0mPpZHDfluvwbJlpc2VTsx5/GPAkWoEfAlLPC7aFDOXYhvlo9hrs8ebZOeNw==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.210.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/token-providers": "3.210.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.210.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.210.0.tgz",
+          "integrity": "sha512-UHoj9eKHQZtEII2U+xcflH8clpLMSDXqY1BDlXBjqeztwMcID6FdT19Agf4rofu4n3Qy3gyxRbcYMfp2AOmeaQ==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.210.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.210.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.210.0.tgz",
+          "integrity": "sha512-OVDTj7QlXo3WvGwSIyKkg3oYaaXOq+mjYdSLu9h0BC8Ul4SnW5iKS9wIy2AhYQKIpgML9ucueUJrCZS3W23I2A==",
+          "requires": {
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/client-s3": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.210.0",
-        "@aws-sdk/client-s3": "^3.209.0",
+        "@aws-sdk/client-s3": "^3.210.0",
         "express": "^4.18.2"
       },
       "devDependencies": {
@@ -234,7 +234,71 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.210.0.tgz",
+      "integrity": "sha512-ZOadr6Bt5PKsHS7zH5VwgvdPrqNkxYJ0fiPa9tM3jc4oyT9U56DkWGgd6UW31EGnySNVuBUPOiu9MjCc7gfFQA==",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.210.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.210.0",
+        "@aws-sdk/eventstream-serde-browser": "3.208.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
+        "@aws-sdk/eventstream-serde-node": "3.208.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-blob-browser": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/hash-stream-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/md5-js": "3.208.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-expect-continue": "3.208.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-location-constraint": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-s3": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/middleware-ssec": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/signature-v4-multi-region": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-stream-browser": "3.208.0",
+        "@aws-sdk/util-stream-node": "3.208.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.208.0",
+        "@aws-sdk/xml-builder": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
       "version": "3.210.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.210.0.tgz",
       "integrity": "sha512-3ZWZF7Vo4d/OhsRZegwGperFUnshkQxz+iBr9Vs+OyR44oX3uMyMUyefSk+78UOc/wK0WPt3zXfEWrV4FkkhAg==",
@@ -276,7 +340,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso-oidc": {
+    "node_modules/@aws-sdk/client-sso-oidc": {
       "version": "3.210.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.210.0.tgz",
       "integrity": "sha512-OAVb7kP7FsfGrnMacdLqt2Tsy/ihp66CaBzxfJiGPg3o1T81nVKLiHGCdEQWRbuFS3jy+C8sJ51kv7dPQYpegQ==",
@@ -318,7 +382,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+    "node_modules/@aws-sdk/client-sts": {
       "version": "3.210.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.210.0.tgz",
       "integrity": "sha512-wbadDc0WS6uy/ITC7w4Ntltloun4sPcgu2YtMb2qH+FjsNNEaZ6XpeaOJYSiBjpLeVy3ipalV69L3fi/LmKDjg==",
@@ -353,281 +417,6 @@
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
         "@aws-sdk/util-endpoints": "3.210.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.210.0.tgz",
-      "integrity": "sha512-vEI7FzV2Zs8pfNtEVPi5eSx+T0V6lIT8a6LlRFnvQeJOliNtreN/li/QA8CIqAmH4ChPmZbYYKvc/Bb/fRf/WQ==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.210.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.210.0.tgz",
-      "integrity": "sha512-J/FtblqkB9SJmZAYe7OS1+gtNom7FCnQkky8crGTuIUCDJBt9VpvRn0juFIfHtkPln56q7myDieH6GNoD+l/sw==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.210.0",
-        "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.210.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.210.0.tgz",
-      "integrity": "sha512-76+fw8ES6bGXUMpbAp0yVX0jEf0mPpZHDfluvwbJlpc2VTsx5/GPAkWoEfAlLPC7aFDOXYhvlo9hrs8ebZOeNw==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.210.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.210.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.210.0.tgz",
-      "integrity": "sha512-UHoj9eKHQZtEII2U+xcflH8clpLMSDXqY1BDlXBjqeztwMcID6FdT19Agf4rofu4n3Qy3gyxRbcYMfp2AOmeaQ==",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.210.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.210.0.tgz",
-      "integrity": "sha512-OVDTj7QlXo3WvGwSIyKkg3oYaaXOq+mjYdSLu9h0BC8Ul4SnW5iKS9wIy2AhYQKIpgML9ucueUJrCZS3W23I2A==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.209.0.tgz",
-      "integrity": "sha512-FKRsG93bqM4Ra+wOgq8Rbg6z7enR5bvPdckfZE5bNVq0mUGCFxcCfurvpAxp4dAtQgLZRhMXIPc1B3wAB/UnmA==",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "2.0.0",
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.209.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
-        "@aws-sdk/eventstream-serde-browser": "3.208.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
-        "@aws-sdk/eventstream-serde-node": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-blob-browser": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/hash-stream-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/md5-js": "3.208.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-expect-continue": "3.208.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-location-constraint": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-s3": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-ssec": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4-multi-region": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
-        "@aws-sdk/util-stream-browser": "3.208.0",
-        "@aws-sdk/util-stream-node": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.208.0",
-        "@aws-sdk/xml-builder": "3.201.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
-      "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.209.0.tgz",
-      "integrity": "sha512-KSmT181IcE32lqoZsS0h400qiL/BSQ84DS1iPOqP0NkLcgnvmOkKygVpYjTql2xSUWLQBwPNFihYJ+jmAj3HtQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
-      "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-sts": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -683,13 +472,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
-      "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.210.0.tgz",
+      "integrity": "sha512-vEI7FzV2Zs8pfNtEVPi5eSx+T0V6lIT8a6LlRFnvQeJOliNtreN/li/QA8CIqAmH4ChPmZbYYKvc/Bb/fRf/WQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.208.0",
         "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.210.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
@@ -701,15 +490,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
-      "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.210.0.tgz",
+      "integrity": "sha512-J/FtblqkB9SJmZAYe7OS1+gtNom7FCnQkky8crGTuIUCDJBt9VpvRn0juFIfHtkPln56q7myDieH6GNoD+l/sw==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.208.0",
         "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.210.0",
         "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.210.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
@@ -735,14 +524,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
-      "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.210.0.tgz",
+      "integrity": "sha512-76+fw8ES6bGXUMpbAp0yVX0jEf0mPpZHDfluvwbJlpc2VTsx5/GPAkWoEfAlLPC7aFDOXYhvlo9hrs8ebZOeNw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.209.0",
+        "@aws-sdk/client-sso": "3.210.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.209.0",
+        "@aws-sdk/token-providers": "3.210.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -1318,11 +1107,11 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.209.0.tgz",
-      "integrity": "sha512-MMtL/yD98SxjejcZYghLN4qhC1TDNeHjnzb+zBcXANxgh5m+QdhERsZkDGU8QiEo+DL6M2HKbwyXu82z89sqnQ==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.210.0.tgz",
+      "integrity": "sha512-UHoj9eKHQZtEII2U+xcflH8clpLMSDXqY1BDlXBjqeztwMcID6FdT19Agf4rofu4n3Qy3gyxRbcYMfp2AOmeaQ==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.209.0",
+        "@aws-sdk/client-sso-oidc": "3.210.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
@@ -1446,9 +1235,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.210.0.tgz",
+      "integrity": "sha512-OVDTj7QlXo3WvGwSIyKkg3oYaaXOq+mjYdSLu9h0BC8Ul4SnW5iKS9wIy2AhYQKIpgML9ucueUJrCZS3W23I2A==",
       "dependencies": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -8354,208 +8143,19 @@
         "@aws-sdk/util-waiter": "3.208.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.210.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.210.0.tgz",
-          "integrity": "sha512-3ZWZF7Vo4d/OhsRZegwGperFUnshkQxz+iBr9Vs+OyR44oX3uMyMUyefSk+78UOc/wK0WPt3zXfEWrV4FkkhAg==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.210.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.210.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.210.0.tgz",
-          "integrity": "sha512-OAVb7kP7FsfGrnMacdLqt2Tsy/ihp66CaBzxfJiGPg3o1T81nVKLiHGCdEQWRbuFS3jy+C8sJ51kv7dPQYpegQ==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.210.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.210.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.210.0.tgz",
-          "integrity": "sha512-wbadDc0WS6uy/ITC7w4Ntltloun4sPcgu2YtMb2qH+FjsNNEaZ6XpeaOJYSiBjpLeVy3ipalV69L3fi/LmKDjg==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/credential-provider-node": "3.210.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-sdk-sts": "3.208.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.210.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.210.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.210.0.tgz",
-          "integrity": "sha512-vEI7FzV2Zs8pfNtEVPi5eSx+T0V6lIT8a6LlRFnvQeJOliNtreN/li/QA8CIqAmH4ChPmZbYYKvc/Bb/fRf/WQ==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/credential-provider-sso": "3.210.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.210.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.210.0.tgz",
-          "integrity": "sha512-J/FtblqkB9SJmZAYe7OS1+gtNom7FCnQkky8crGTuIUCDJBt9VpvRn0juFIfHtkPln56q7myDieH6GNoD+l/sw==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/credential-provider-ini": "3.210.0",
-            "@aws-sdk/credential-provider-process": "3.209.0",
-            "@aws-sdk/credential-provider-sso": "3.210.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.210.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.210.0.tgz",
-          "integrity": "sha512-76+fw8ES6bGXUMpbAp0yVX0jEf0mPpZHDfluvwbJlpc2VTsx5/GPAkWoEfAlLPC7aFDOXYhvlo9hrs8ebZOeNw==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.210.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/token-providers": "3.210.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.210.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.210.0.tgz",
-          "integrity": "sha512-UHoj9eKHQZtEII2U+xcflH8clpLMSDXqY1BDlXBjqeztwMcID6FdT19Agf4rofu4n3Qy3gyxRbcYMfp2AOmeaQ==",
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.210.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.210.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.210.0.tgz",
-          "integrity": "sha512-OVDTj7QlXo3WvGwSIyKkg3oYaaXOq+mjYdSLu9h0BC8Ul4SnW5iKS9wIy2AhYQKIpgML9ucueUJrCZS3W23I2A==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.209.0.tgz",
-      "integrity": "sha512-FKRsG93bqM4Ra+wOgq8Rbg6z7enR5bvPdckfZE5bNVq0mUGCFxcCfurvpAxp4dAtQgLZRhMXIPc1B3wAB/UnmA==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.210.0.tgz",
+      "integrity": "sha512-ZOadr6Bt5PKsHS7zH5VwgvdPrqNkxYJ0fiPa9tM3jc4oyT9U56DkWGgd6UW31EGnySNVuBUPOiu9MjCc7gfFQA==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/client-sts": "3.210.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.210.0",
         "@aws-sdk/eventstream-serde-browser": "3.208.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
         "@aws-sdk/eventstream-serde-node": "3.208.0",
@@ -8593,7 +8193,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
         "@aws-sdk/util-stream-browser": "3.208.0",
         "@aws-sdk/util-stream-node": "3.208.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
@@ -8607,9 +8207,9 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
-      "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.210.0.tgz",
+      "integrity": "sha512-3ZWZF7Vo4d/OhsRZegwGperFUnshkQxz+iBr9Vs+OyR44oX3uMyMUyefSk+78UOc/wK0WPt3zXfEWrV4FkkhAg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -8637,7 +8237,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -8646,9 +8246,9 @@
       }
     },
     "@aws-sdk/client-sso-oidc": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.209.0.tgz",
-      "integrity": "sha512-KSmT181IcE32lqoZsS0h400qiL/BSQ84DS1iPOqP0NkLcgnvmOkKygVpYjTql2xSUWLQBwPNFihYJ+jmAj3HtQ==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.210.0.tgz",
+      "integrity": "sha512-OAVb7kP7FsfGrnMacdLqt2Tsy/ihp66CaBzxfJiGPg3o1T81nVKLiHGCdEQWRbuFS3jy+C8sJ51kv7dPQYpegQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -8676,7 +8276,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -8685,14 +8285,14 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
-      "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.210.0.tgz",
+      "integrity": "sha512-wbadDc0WS6uy/ITC7w4Ntltloun4sPcgu2YtMb2qH+FjsNNEaZ6XpeaOJYSiBjpLeVy3ipalV69L3fi/LmKDjg==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.210.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -8718,7 +8318,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.210.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -8762,13 +8362,13 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
-      "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.210.0.tgz",
+      "integrity": "sha512-vEI7FzV2Zs8pfNtEVPi5eSx+T0V6lIT8a6LlRFnvQeJOliNtreN/li/QA8CIqAmH4ChPmZbYYKvc/Bb/fRf/WQ==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.208.0",
         "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.210.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
@@ -8777,15 +8377,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
-      "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.210.0.tgz",
+      "integrity": "sha512-J/FtblqkB9SJmZAYe7OS1+gtNom7FCnQkky8crGTuIUCDJBt9VpvRn0juFIfHtkPln56q7myDieH6GNoD+l/sw==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.208.0",
         "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.210.0",
         "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.210.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
@@ -8805,14 +8405,14 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
-      "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.210.0.tgz",
+      "integrity": "sha512-76+fw8ES6bGXUMpbAp0yVX0jEf0mPpZHDfluvwbJlpc2VTsx5/GPAkWoEfAlLPC7aFDOXYhvlo9hrs8ebZOeNw==",
       "requires": {
-        "@aws-sdk/client-sso": "3.209.0",
+        "@aws-sdk/client-sso": "3.210.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.209.0",
+        "@aws-sdk/token-providers": "3.210.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }
@@ -9263,11 +8863,11 @@
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.209.0.tgz",
-      "integrity": "sha512-MMtL/yD98SxjejcZYghLN4qhC1TDNeHjnzb+zBcXANxgh5m+QdhERsZkDGU8QiEo+DL6M2HKbwyXu82z89sqnQ==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.210.0.tgz",
+      "integrity": "sha512-UHoj9eKHQZtEII2U+xcflH8clpLMSDXqY1BDlXBjqeztwMcID6FdT19Agf4rofu4n3Qy3gyxRbcYMfp2AOmeaQ==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.209.0",
+        "@aws-sdk/client-sso-oidc": "3.210.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
@@ -9364,9 +8964,9 @@
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
+      "version": "3.210.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.210.0.tgz",
+      "integrity": "sha512-OVDTj7QlXo3WvGwSIyKkg3oYaaXOq+mjYdSLu9h0BC8Ul4SnW5iKS9wIy2AhYQKIpgML9ucueUJrCZS3W23I2A==",
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.208.0",
-        "@aws-sdk/client-s3": "^3.208.0",
+        "@aws-sdk/client-s3": "^3.209.0",
         "express": "^4.18.2"
       },
       "devDependencies": {
@@ -237,16 +237,16 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.208.0.tgz",
-      "integrity": "sha512-NBwSB8IwZ18cVEP1tEBtZ9f/dp5mEhSZnqwWYtOtLgcSyCMJSklVEtrN+CvGGIV6Ut1gwyL3trKT5qWONChO1g==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.209.0.tgz",
+      "integrity": "sha512-FKRsG93bqM4Ra+wOgq8Rbg6z7enR5bvPdckfZE5bNVq0mUGCFxcCfurvpAxp4dAtQgLZRhMXIPc1B3wAB/UnmA==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.208.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.209.0",
         "@aws-sdk/eventstream-serde-browser": "3.208.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
         "@aws-sdk/eventstream-serde-node": "3.208.0",
@@ -256,7 +256,7 @@
         "@aws-sdk/hash-stream-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
         "@aws-sdk/md5-js": "3.208.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.208.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
         "@aws-sdk/middleware-content-length": "3.208.0",
         "@aws-sdk/middleware-endpoint": "3.208.0",
         "@aws-sdk/middleware-expect-continue": "3.208.0",
@@ -265,32 +265,30 @@
         "@aws-sdk/middleware-location-constraint": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
-        "@aws-sdk/middleware-sdk-s3": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-s3": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-ssec": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/signature-v4-multi-region": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-stream-browser": "3.208.0",
         "@aws-sdk/util-stream-node": "3.208.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "@aws-sdk/util-waiter": "3.208.0",
@@ -300,6 +298,310 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
+      "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
+      "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-sts": "3.208.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
+      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
+      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
+      "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.209.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
+      "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.209.0",
+        "@aws-sdk/credential-provider-process": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.209.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
+      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
+      "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/token-providers": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
+      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/service-error-classification": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
+      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
+      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
+      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
+      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
+      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
+      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -344,6 +646,196 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.209.0.tgz",
+      "integrity": "sha512-KSmT181IcE32lqoZsS0h400qiL/BSQ84DS1iPOqP0NkLcgnvmOkKygVpYjTql2xSUWLQBwPNFihYJ+jmAj3HtQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
+      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
+      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
+      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/service-error-classification": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/util-middleware": "3.208.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
+      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
+      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
+      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
+      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
+      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
+      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-sts": {
@@ -671,9 +1163,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.208.0.tgz",
-      "integrity": "sha512-ttvwDsYfQRZRC/1Lbn50jlY4haK35DFt6IP7UdcI1R0aycM81LJYsTCgZ3yjAmouBZ7AX4IH7CCGeDcl0q0USg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.209.0.tgz",
+      "integrity": "sha512-H7yKwR7ephdXWTfHjqs9Opc9hpdrHnRpWWcpeUcDVKK5G+8yb99y0XhJx0n43v+bzk4uo91mAg3eBdTX0AgHmA==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -827,11 +1319,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.208.0.tgz",
-      "integrity": "sha512-YX4BGgUuo/GO2J/8KRS4arSOaBJe9nxouV+MH+ESfPYIetY1p9fEPDYU9p1j69+tKF13ER728msaa16Zb1HEYA==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.209.0.tgz",
+      "integrity": "sha512-vmWKoWbgmO+GKVdu4jw5fk/x0thBYBkx349jS4jGB81Y8erv5V8M5rautcvb1oSTW+oh5Q8ZW07SgaPaLfjsAw==",
       "dependencies": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.208.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
@@ -1064,6 +1556,33 @@
       "integrity": "sha512-4SGPAs7ZtG9AUYknJNkZTs+ww1cpdcPth5te+R/dN4anUbqtL2qvmbdZJ+8rzdAZKndXu0huKE1OZrR3COLciw==",
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.209.0.tgz",
+      "integrity": "sha512-MMtL/yD98SxjejcZYghLN4qhC1TDNeHjnzb+zBcXANxgh5m+QdhERsZkDGU8QiEo+DL6M2HKbwyXu82z89sqnQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
+      "dependencies": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -8118,16 +8637,16 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.208.0.tgz",
-      "integrity": "sha512-NBwSB8IwZ18cVEP1tEBtZ9f/dp5mEhSZnqwWYtOtLgcSyCMJSklVEtrN+CvGGIV6Ut1gwyL3trKT5qWONChO1g==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.209.0.tgz",
+      "integrity": "sha512-FKRsG93bqM4Ra+wOgq8Rbg6z7enR5bvPdckfZE5bNVq0mUGCFxcCfurvpAxp4dAtQgLZRhMXIPc1B3wAB/UnmA==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.208.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.209.0",
         "@aws-sdk/eventstream-serde-browser": "3.208.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
         "@aws-sdk/eventstream-serde-node": "3.208.0",
@@ -8137,7 +8656,7 @@
         "@aws-sdk/hash-stream-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
         "@aws-sdk/md5-js": "3.208.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.208.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
         "@aws-sdk/middleware-content-length": "3.208.0",
         "@aws-sdk/middleware-endpoint": "3.208.0",
         "@aws-sdk/middleware-expect-continue": "3.208.0",
@@ -8146,38 +8665,286 @@
         "@aws-sdk/middleware-location-constraint": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
-        "@aws-sdk/middleware-sdk-s3": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-s3": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-ssec": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/signature-v4-multi-region": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-stream-browser": "3.208.0",
         "@aws-sdk/util-stream-node": "3.208.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "@aws-sdk/util-waiter": "3.208.0",
         "@aws-sdk/xml-builder": "3.201.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
+          "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/fetch-http-handler": "3.208.0",
+            "@aws-sdk/hash-node": "3.208.0",
+            "@aws-sdk/invalid-dependency": "3.208.0",
+            "@aws-sdk/middleware-content-length": "3.208.0",
+            "@aws-sdk/middleware-endpoint": "3.208.0",
+            "@aws-sdk/middleware-host-header": "3.208.0",
+            "@aws-sdk/middleware-logger": "3.208.0",
+            "@aws-sdk/middleware-recursion-detection": "3.208.0",
+            "@aws-sdk/middleware-retry": "3.209.0",
+            "@aws-sdk/middleware-serde": "3.208.0",
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/middleware-user-agent": "3.208.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/node-http-handler": "3.208.0",
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/smithy-client": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+            "@aws-sdk/util-defaults-mode-node": "3.209.0",
+            "@aws-sdk/util-endpoints": "3.209.0",
+            "@aws-sdk/util-user-agent-browser": "3.208.0",
+            "@aws-sdk/util-user-agent-node": "3.209.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
+          "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/credential-provider-node": "3.209.0",
+            "@aws-sdk/fetch-http-handler": "3.208.0",
+            "@aws-sdk/hash-node": "3.208.0",
+            "@aws-sdk/invalid-dependency": "3.208.0",
+            "@aws-sdk/middleware-content-length": "3.208.0",
+            "@aws-sdk/middleware-endpoint": "3.208.0",
+            "@aws-sdk/middleware-host-header": "3.208.0",
+            "@aws-sdk/middleware-logger": "3.208.0",
+            "@aws-sdk/middleware-recursion-detection": "3.208.0",
+            "@aws-sdk/middleware-retry": "3.209.0",
+            "@aws-sdk/middleware-sdk-sts": "3.208.0",
+            "@aws-sdk/middleware-serde": "3.208.0",
+            "@aws-sdk/middleware-signing": "3.208.0",
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/middleware-user-agent": "3.208.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/node-http-handler": "3.208.0",
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/smithy-client": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+            "@aws-sdk/util-defaults-mode-node": "3.209.0",
+            "@aws-sdk/util-endpoints": "3.209.0",
+            "@aws-sdk/util-user-agent-browser": "3.208.0",
+            "@aws-sdk/util-user-agent-node": "3.209.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
+          "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
+          "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
+          "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.208.0",
+            "@aws-sdk/credential-provider-imds": "3.209.0",
+            "@aws-sdk/credential-provider-sso": "3.209.0",
+            "@aws-sdk/credential-provider-web-identity": "3.208.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
+          "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.208.0",
+            "@aws-sdk/credential-provider-imds": "3.209.0",
+            "@aws-sdk/credential-provider-ini": "3.209.0",
+            "@aws-sdk/credential-provider-process": "3.209.0",
+            "@aws-sdk/credential-provider-sso": "3.209.0",
+            "@aws-sdk/credential-provider-web-identity": "3.208.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
+          "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
+          "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.209.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/token-providers": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
+          "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/service-error-classification": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/util-middleware": "3.208.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
+          "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
+          "requires": {
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
+          "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
+          "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
+          "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/credential-provider-imds": "3.209.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
+          "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
+          "requires": {
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
+          "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso": {
@@ -8219,6 +8986,157 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.209.0.tgz",
+      "integrity": "sha512-KSmT181IcE32lqoZsS0h400qiL/BSQ84DS1iPOqP0NkLcgnvmOkKygVpYjTql2xSUWLQBwPNFihYJ+jmAj3HtQ==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/config-resolver": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
+          "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
+          "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
+          "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/service-error-classification": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/util-middleware": "3.208.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
+          "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
+          "requires": {
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
+          "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
+          "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
+          "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/credential-provider-imds": "3.209.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
+          "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
+          "requires": {
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
+          "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/client-sts": {
@@ -8495,9 +9413,9 @@
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.208.0.tgz",
-      "integrity": "sha512-ttvwDsYfQRZRC/1Lbn50jlY4haK35DFt6IP7UdcI1R0aycM81LJYsTCgZ3yjAmouBZ7AX4IH7CCGeDcl0q0USg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.209.0.tgz",
+      "integrity": "sha512-H7yKwR7ephdXWTfHjqs9Opc9hpdrHnRpWWcpeUcDVKK5G+8yb99y0XhJx0n43v+bzk4uo91mAg3eBdTX0AgHmA==",
       "requires": {
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -8618,11 +9536,11 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.208.0.tgz",
-      "integrity": "sha512-YX4BGgUuo/GO2J/8KRS4arSOaBJe9nxouV+MH+ESfPYIetY1p9fEPDYU9p1j69+tKF13ER728msaa16Zb1HEYA==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.209.0.tgz",
+      "integrity": "sha512-vmWKoWbgmO+GKVdu4jw5fk/x0thBYBkx349jS4jGB81Y8erv5V8M5rautcvb1oSTW+oh5Q8ZW07SgaPaLfjsAw==",
       "requires": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.208.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
@@ -8798,6 +9716,29 @@
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.209.0.tgz",
+      "integrity": "sha512-MMtL/yD98SxjejcZYghLN4qhC1TDNeHjnzb+zBcXANxgh5m+QdhERsZkDGU8QiEo+DL6M2HKbwyXu82z89sqnQ==",
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.209.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.209.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
+          "requires": {
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/types": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.210.0",
+        "@aws-sdk/client-dynamodb": "^3.211.0",
         "@aws-sdk/client-s3": "^3.210.0",
         "express": "^4.18.2"
       },
@@ -187,15 +187,15 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.210.0.tgz",
-      "integrity": "sha512-umSGa1ShdeqifnxAx7jEZryd0MgSQMZXhNc0jfwONzDbRaGaOEQLuL9dRARfT7vtUWjV4wpxv+PBfQjtJHICog==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.211.0.tgz",
+      "integrity": "sha512-SoinZ+k1TgY/99dUZ2S+FH+sXG3+BaFaSd98if0dygTqIftq9ctaRbDQFss64hdrqu6Qpuvak4XhqaRMaQOr2A==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.210.0",
+        "@aws-sdk/client-sts": "3.211.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.210.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -221,7 +221,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -229,6 +229,217 @@
         "@aws-sdk/util-waiter": "3.208.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
+      "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
+      "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
+      "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
+        "@aws-sdk/fetch-http-handler": "3.208.0",
+        "@aws-sdk/hash-node": "3.208.0",
+        "@aws-sdk/invalid-dependency": "3.208.0",
+        "@aws-sdk/middleware-content-length": "3.208.0",
+        "@aws-sdk/middleware-endpoint": "3.208.0",
+        "@aws-sdk/middleware-host-header": "3.208.0",
+        "@aws-sdk/middleware-logger": "3.208.0",
+        "@aws-sdk/middleware-recursion-detection": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
+        "@aws-sdk/middleware-sdk-sts": "3.208.0",
+        "@aws-sdk/middleware-serde": "3.208.0",
+        "@aws-sdk/middleware-signing": "3.208.0",
+        "@aws-sdk/middleware-stack": "3.208.0",
+        "@aws-sdk/middleware-user-agent": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
+        "@aws-sdk/node-http-handler": "3.208.0",
+        "@aws-sdk/protocol-http": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
+        "@aws-sdk/util-user-agent-browser": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
+      "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
+      "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.211.0",
+        "@aws-sdk/credential-provider-process": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.211.0",
+        "@aws-sdk/credential-provider-web-identity": "3.208.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
+      "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.211.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/token-providers": "3.211.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/token-providers": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
+      "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.211.0",
+        "@aws-sdk/property-provider": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
+      "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.208.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -8101,15 +8312,15 @@
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.210.0.tgz",
-      "integrity": "sha512-umSGa1ShdeqifnxAx7jEZryd0MgSQMZXhNc0jfwONzDbRaGaOEQLuL9dRARfT7vtUWjV4wpxv+PBfQjtJHICog==",
+      "version": "3.211.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.211.0.tgz",
+      "integrity": "sha512-SoinZ+k1TgY/99dUZ2S+FH+sXG3+BaFaSd98if0dygTqIftq9ctaRbDQFss64hdrqu6Qpuvak4XhqaRMaQOr2A==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.210.0",
+        "@aws-sdk/client-sts": "3.211.0",
         "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.210.0",
+        "@aws-sdk/credential-provider-node": "3.211.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -8135,7 +8346,7 @@
         "@aws-sdk/util-body-length-node": "3.208.0",
         "@aws-sdk/util-defaults-mode-browser": "3.209.0",
         "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.210.0",
+        "@aws-sdk/util-endpoints": "3.211.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -8143,6 +8354,195 @@
         "@aws-sdk/util-waiter": "3.208.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@aws-sdk/client-sso": {
+          "version": "3.211.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
+          "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/fetch-http-handler": "3.208.0",
+            "@aws-sdk/hash-node": "3.208.0",
+            "@aws-sdk/invalid-dependency": "3.208.0",
+            "@aws-sdk/middleware-content-length": "3.208.0",
+            "@aws-sdk/middleware-endpoint": "3.208.0",
+            "@aws-sdk/middleware-host-header": "3.208.0",
+            "@aws-sdk/middleware-logger": "3.208.0",
+            "@aws-sdk/middleware-recursion-detection": "3.208.0",
+            "@aws-sdk/middleware-retry": "3.209.0",
+            "@aws-sdk/middleware-serde": "3.208.0",
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/middleware-user-agent": "3.208.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/node-http-handler": "3.208.0",
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/smithy-client": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+            "@aws-sdk/util-defaults-mode-node": "3.209.0",
+            "@aws-sdk/util-endpoints": "3.211.0",
+            "@aws-sdk/util-user-agent-browser": "3.208.0",
+            "@aws-sdk/util-user-agent-node": "3.209.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.211.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
+          "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/fetch-http-handler": "3.208.0",
+            "@aws-sdk/hash-node": "3.208.0",
+            "@aws-sdk/invalid-dependency": "3.208.0",
+            "@aws-sdk/middleware-content-length": "3.208.0",
+            "@aws-sdk/middleware-endpoint": "3.208.0",
+            "@aws-sdk/middleware-host-header": "3.208.0",
+            "@aws-sdk/middleware-logger": "3.208.0",
+            "@aws-sdk/middleware-recursion-detection": "3.208.0",
+            "@aws-sdk/middleware-retry": "3.209.0",
+            "@aws-sdk/middleware-serde": "3.208.0",
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/middleware-user-agent": "3.208.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/node-http-handler": "3.208.0",
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/smithy-client": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+            "@aws-sdk/util-defaults-mode-node": "3.209.0",
+            "@aws-sdk/util-endpoints": "3.211.0",
+            "@aws-sdk/util-user-agent-browser": "3.208.0",
+            "@aws-sdk/util-user-agent-node": "3.209.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.211.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
+          "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.209.0",
+            "@aws-sdk/credential-provider-node": "3.211.0",
+            "@aws-sdk/fetch-http-handler": "3.208.0",
+            "@aws-sdk/hash-node": "3.208.0",
+            "@aws-sdk/invalid-dependency": "3.208.0",
+            "@aws-sdk/middleware-content-length": "3.208.0",
+            "@aws-sdk/middleware-endpoint": "3.208.0",
+            "@aws-sdk/middleware-host-header": "3.208.0",
+            "@aws-sdk/middleware-logger": "3.208.0",
+            "@aws-sdk/middleware-recursion-detection": "3.208.0",
+            "@aws-sdk/middleware-retry": "3.209.0",
+            "@aws-sdk/middleware-sdk-sts": "3.208.0",
+            "@aws-sdk/middleware-serde": "3.208.0",
+            "@aws-sdk/middleware-signing": "3.208.0",
+            "@aws-sdk/middleware-stack": "3.208.0",
+            "@aws-sdk/middleware-user-agent": "3.208.0",
+            "@aws-sdk/node-config-provider": "3.209.0",
+            "@aws-sdk/node-http-handler": "3.208.0",
+            "@aws-sdk/protocol-http": "3.208.0",
+            "@aws-sdk/smithy-client": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "@aws-sdk/url-parser": "3.208.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+            "@aws-sdk/util-defaults-mode-node": "3.209.0",
+            "@aws-sdk/util-endpoints": "3.211.0",
+            "@aws-sdk/util-user-agent-browser": "3.208.0",
+            "@aws-sdk/util-user-agent-node": "3.209.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.211.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
+          "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.208.0",
+            "@aws-sdk/credential-provider-imds": "3.209.0",
+            "@aws-sdk/credential-provider-sso": "3.211.0",
+            "@aws-sdk/credential-provider-web-identity": "3.208.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.211.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
+          "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.208.0",
+            "@aws-sdk/credential-provider-imds": "3.209.0",
+            "@aws-sdk/credential-provider-ini": "3.211.0",
+            "@aws-sdk/credential-provider-process": "3.209.0",
+            "@aws-sdk/credential-provider-sso": "3.211.0",
+            "@aws-sdk/credential-provider-web-identity": "3.208.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.211.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
+          "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.211.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/token-providers": "3.211.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.211.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
+          "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.211.0",
+            "@aws-sdk/property-provider": "3.208.0",
+            "@aws-sdk/shared-ini-file-loader": "3.209.0",
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.211.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
+          "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
+          "requires": {
+            "@aws-sdk/types": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/client-s3": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.208.0",
+        "@aws-sdk/client-dynamodb": "^3.209.0",
         "@aws-sdk/client-s3": "^3.209.0",
         "express": "^4.18.2"
       },
@@ -187,45 +187,43 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.208.0.tgz",
-      "integrity": "sha512-+guT9SC1n/eJ5cdrruCXs4q8q/eoeqSF2siGDyE7+0QMaUbkwWBWJkv6jjxHSVvfLkLkQIn2foJ4gaRj23qXRQ==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.209.0.tgz",
+      "integrity": "sha512-m+04jiyNzBLETphijusiyxXRklf9R58SDXQKKwP7LoDliU6ko76XjAwKVZsVwvM98xPMp8LEDUjoTCw+TdxMnw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.208.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.209.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
         "@aws-sdk/middleware-content-length": "3.208.0",
         "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.208.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.209.0",
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "@aws-sdk/util-waiter": "3.208.0",
@@ -300,7 +298,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+    "node_modules/@aws-sdk/client-sso": {
       "version": "3.209.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
       "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
@@ -334,312 +332,6 @@
         "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
         "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
-      "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.209.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-sts": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.209.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.208.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
-      "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.209.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
-      "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/credential-provider-ini": "3.209.0",
-        "@aws-sdk/credential-provider-process": "3.209.0",
-        "@aws-sdk/credential-provider-sso": "3.209.0",
-        "@aws-sdk/credential-provider-web-identity": "3.208.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
-      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
-      "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/token-providers": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/service-error-classification": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.208.0.tgz",
-      "integrity": "sha512-3e6kEFtuxqZVv1cLGbXFAytTPzR1GpctKITEtJR0MFy3pzj8ttbybrHe0F8z2AqAtDhna1i3u1WVZa+LK3gE9Q==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
@@ -690,163 +382,15 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/config-resolver": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-config-provider": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/service-error-classification": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/util-middleware": "3.208.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/smithy-client": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-imds": "3.209.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.208.0.tgz",
-      "integrity": "sha512-xmPxI/vW0YVm2YhmIfdTQYY8b8dvzP0ordgooDlzAZVj5KnpZLVzQUxin5EqVcZYFJp6qEkVwmFK03QLy9fYOw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
+      "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.209.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -855,28 +399,26 @@
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-sdk-sts": "3.208.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "fast-xml-parser": "4.0.11",
@@ -887,9 +429,9 @@
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-      "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
+      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
       "dependencies": {
         "@aws-sdk/signature-v4": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -915,11 +457,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.208.0.tgz",
-      "integrity": "sha512-z4Bk42FQefBzS1SZ6/4gsAFE7tQhEoDmSUrFVSDu/9WwvGpFMnFfHLTBhivlcAHjc/eQ/hiWYLnQ8vahqhHl8w==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
+      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
@@ -930,16 +472,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.208.0.tgz",
-      "integrity": "sha512-AhsUj4046wMnxrPunNVEuddOIb//KsaicRqucw1Pb/UqszDRO4hYWkw7pL10MPIqjHBwuXYZ3vjDZrIhIWMn7A==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
+      "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/credential-provider-sso": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.209.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -948,18 +490,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.208.0.tgz",
-      "integrity": "sha512-KYoxlpDzvhw6v0ae0TgIGPP52HJUHQGI3yImhAZZTz0Nh5B0zd2stip+p36sCYRW6V+TJ5mo5minwqDmYe8oXg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
+      "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/credential-provider-ini": "3.208.0",
-        "@aws-sdk/credential-provider-process": "3.208.0",
-        "@aws-sdk/credential-provider-sso": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.209.0",
+        "@aws-sdk/credential-provider-process": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.209.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -968,12 +510,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.208.0.tgz",
-      "integrity": "sha512-ExvFSJB/pVV+/BXIvFR9dgoGxWWnF6uqIw1hfpWCh28UDwsOQdbfUKblMovUfPDBUw67Laqy3mtiY37Jyo/EUQ==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
+      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
       "dependencies": {
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -982,13 +524,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.208.0.tgz",
-      "integrity": "sha512-GVUBmSG8eO4oXy5XpslAgVUBimEVBYmyCdwrwED79ey/7NWfkIVt46VZQapWyAJsarKW+VFpx7BYnam9YBR6hA==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
+      "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.208.0",
+        "@aws-sdk/client-sso": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/token-providers": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -1209,11 +752,11 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.208.0.tgz",
-      "integrity": "sha512-RSbqxZ/oVBY7VvIjwm8ZrpcI4jd+oZZJVXNA2H++J12yEVGNLYOFXZzUatq+Z8ryfuugdsvfMYvVA64qzT8rQw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.209.0.tgz",
+      "integrity": "sha512-ZBWYhTBfdc/bUNB1N4jL8ZW7NmKTkdowbZHTlxtXi8ySzzn+qlD+XosIEbXqrVR9sYxSVC3kwsQvADxHzKGixw==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
         "@aws-sdk/endpoint-cache": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -1303,9 +846,9 @@
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.208.0.tgz",
-      "integrity": "sha512-JAcN2e3PKWGcNX7run/jP6xJ7w2m15a2CpVrfMtka9p/I/3qnqB86jGUs/3Iv04FEqgXq7KTHbFBg8CndsaHEw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
+      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/service-error-classification": "3.208.0",
@@ -1414,12 +957,12 @@
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.208.0.tgz",
-      "integrity": "sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
+      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
       "dependencies": {
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -1500,9 +1043,9 @@
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.208.0.tgz",
-      "integrity": "sha512-ZDmwOLNiBKfvtN1M2eG2bItw0+4hKDU/XKqB+yVI9Uo29o4XwtQ4Br7HixTlPYJAavmM1cCch8PVvnwngYAKPA==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
       "dependencies": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -1551,9 +1094,9 @@
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.208.0.tgz",
-      "integrity": "sha512-4SGPAs7ZtG9AUYknJNkZTs+ww1cpdcPth5te+R/dN4anUbqtL2qvmbdZJ+8rzdAZKndXu0huKE1OZrR3COLciw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
+      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -1571,18 +1114,6 @@
         "@aws-sdk/client-sso-oidc": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-      "dependencies": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -1623,26 +1154,6 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
       "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.208.0.tgz",
-      "integrity": "sha512-nR6S6aZqlr//Sy3+2J7G2mn5XG1ELBBTswvbp6kCo5BK9v/kESuzsHC5b6f3xzl/TY4JSG8Aj+h7x+kZHfKwwg==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.208.0.tgz",
-      "integrity": "sha512-tCkSexa90loq8yU+BKAX5WIVQGq8IM/DdFhFphQd1azgOIBYxafA/aVw9mDY+to0mq4QRHiUwmUsmzLWEFSDJg==",
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
@@ -1694,9 +1205,9 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.208.0.tgz",
-      "integrity": "sha512-i4cA074pycou1BPr7axFMiK3iHv+Tzjl/ZiN3Yc0BQDLWC9AQdrNodB4WAKnn4a4fWgA/MadfzKXnW1oltSzIg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
+      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
       "dependencies": {
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -1708,13 +1219,13 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.208.0.tgz",
-      "integrity": "sha512-y9dENqcmiUb7/D3uwJsE/fV+RZ9CUc/cs4OcofO81sU29xz8Fg/XQarjSdGVZMTnrDd190GXymMcB4qpOYhtPw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
+      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -1724,9 +1235,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.208.0.tgz",
-      "integrity": "sha512-FGJA07iEbC883bAaw0qtDrly5Y+1nR3ic+OOzGX2AsSgaeVAc1j8Lgg3br7ofBbr8p81ec6zN4syy4v7V0Wb0A==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
+      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
       "dependencies": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -1817,11 +1328,11 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.208.0.tgz",
-      "integrity": "sha512-T7V3TTc+NdcHgITo8yMUDs/qR0wfPjURUrCixHPtqYkqvhoF6YrHUAoCbOcz7SG/Tsm2GgSKAHB4ip9D2QLg4g==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
+      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -8590,45 +8101,43 @@
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.208.0.tgz",
-      "integrity": "sha512-+guT9SC1n/eJ5cdrruCXs4q8q/eoeqSF2siGDyE7+0QMaUbkwWBWJkv6jjxHSVvfLkLkQIn2foJ4gaRj23qXRQ==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.209.0.tgz",
+      "integrity": "sha512-m+04jiyNzBLETphijusiyxXRklf9R58SDXQKKwP7LoDliU6ko76XjAwKVZsVwvM98xPMp8LEDUjoTCw+TdxMnw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.208.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/client-sts": "3.209.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.209.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
         "@aws-sdk/middleware-content-length": "3.208.0",
         "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.208.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.209.0",
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "@aws-sdk/util-waiter": "3.208.0",
@@ -8695,266 +8204,16 @@
         "@aws-sdk/xml-builder": "3.201.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
-          "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.209.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
-          "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "2.0.0",
-            "@aws-crypto/sha256-js": "2.0.0",
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/credential-provider-node": "3.209.0",
-            "@aws-sdk/fetch-http-handler": "3.208.0",
-            "@aws-sdk/hash-node": "3.208.0",
-            "@aws-sdk/invalid-dependency": "3.208.0",
-            "@aws-sdk/middleware-content-length": "3.208.0",
-            "@aws-sdk/middleware-endpoint": "3.208.0",
-            "@aws-sdk/middleware-host-header": "3.208.0",
-            "@aws-sdk/middleware-logger": "3.208.0",
-            "@aws-sdk/middleware-recursion-detection": "3.208.0",
-            "@aws-sdk/middleware-retry": "3.209.0",
-            "@aws-sdk/middleware-sdk-sts": "3.208.0",
-            "@aws-sdk/middleware-serde": "3.208.0",
-            "@aws-sdk/middleware-signing": "3.208.0",
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/middleware-user-agent": "3.208.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/node-http-handler": "3.208.0",
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/smithy-client": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "@aws-sdk/util-base64": "3.208.0",
-            "@aws-sdk/util-body-length-browser": "3.188.0",
-            "@aws-sdk/util-body-length-node": "3.208.0",
-            "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-            "@aws-sdk/util-defaults-mode-node": "3.209.0",
-            "@aws-sdk/util-endpoints": "3.209.0",
-            "@aws-sdk/util-user-agent-browser": "3.208.0",
-            "@aws-sdk/util-user-agent-node": "3.209.0",
-            "@aws-sdk/util-utf8-browser": "3.188.0",
-            "@aws-sdk/util-utf8-node": "3.208.0",
-            "fast-xml-parser": "4.0.11",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/config-resolver": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-          "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-          "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
-          "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/credential-provider-sso": "3.209.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
-          "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.208.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/credential-provider-ini": "3.209.0",
-            "@aws-sdk/credential-provider-process": "3.209.0",
-            "@aws-sdk/credential-provider-sso": "3.209.0",
-            "@aws-sdk/credential-provider-web-identity": "3.208.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
-          "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
-          "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/token-providers": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-          "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/service-error-classification": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-          "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-          "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-          "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-          "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-          "requires": {
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-          "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-          "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.208.0.tgz",
-      "integrity": "sha512-3e6kEFtuxqZVv1cLGbXFAytTPzR1GpctKITEtJR0MFy3pzj8ttbybrHe0F8z2AqAtDhna1i3u1WVZa+LK3gE9Q==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.209.0.tgz",
+      "integrity": "sha512-rh9QktLCOVTbvDzCb0ikSe4Q1I35Wxcx5XZ7k1J+2ze54FOBfCr3vOwcQpo5tpYWEe1Ysbt3gvA8RAqj9oDFdw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -8963,26 +8222,24 @@
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
@@ -9025,129 +8282,17 @@
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/config-resolver": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-          "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-          "requires": {
-            "@aws-sdk/signature-v4": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-config-provider": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/credential-provider-imds": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-          "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/url-parser": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/middleware-retry": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-          "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-          "requires": {
-            "@aws-sdk/protocol-http": "3.208.0",
-            "@aws-sdk/service-error-classification": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "@aws-sdk/util-middleware": "3.208.0",
-            "tslib": "^2.3.1",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@aws-sdk/node-config-provider": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-          "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/shared-ini-file-loader": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/smithy-client": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-          "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-          "requires": {
-            "@aws-sdk/middleware-stack": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-          "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-          "requires": {
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-          "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-          "requires": {
-            "@aws-sdk/config-resolver": "3.209.0",
-            "@aws-sdk/credential-provider-imds": "3.209.0",
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/property-provider": "3.208.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
-          "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-          "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-          "requires": {
-            "@aws-sdk/node-config-provider": "3.209.0",
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.208.0.tgz",
-      "integrity": "sha512-xmPxI/vW0YVm2YhmIfdTQYY8b8dvzP0ordgooDlzAZVj5KnpZLVzQUxin5EqVcZYFJp6qEkVwmFK03QLy9fYOw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.209.0.tgz",
+      "integrity": "sha512-zWlM+9/JbshEgrG79KZlqYusUziKiKqe8vRlvQ9wcuEHNbQnAri4UvObEKik+7YpTBeP3mR+US1T71G0PqJByw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-node": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-node": "3.209.0",
         "@aws-sdk/fetch-http-handler": "3.208.0",
         "@aws-sdk/hash-node": "3.208.0",
         "@aws-sdk/invalid-dependency": "3.208.0",
@@ -9156,28 +8301,26 @@
         "@aws-sdk/middleware-host-header": "3.208.0",
         "@aws-sdk/middleware-logger": "3.208.0",
         "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.208.0",
+        "@aws-sdk/middleware-retry": "3.209.0",
         "@aws-sdk/middleware-sdk-sts": "3.208.0",
         "@aws-sdk/middleware-serde": "3.208.0",
         "@aws-sdk/middleware-signing": "3.208.0",
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/node-http-handler": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/smithy-client": "3.208.0",
+        "@aws-sdk/smithy-client": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
         "@aws-sdk/util-base64": "3.208.0",
-        "@aws-sdk/util-base64-browser": "3.208.0",
-        "@aws-sdk/util-base64-node": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.208.0",
-        "@aws-sdk/util-defaults-mode-node": "3.208.0",
-        "@aws-sdk/util-endpoints": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
+        "@aws-sdk/util-defaults-mode-node": "3.209.0",
+        "@aws-sdk/util-endpoints": "3.209.0",
         "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.208.0",
+        "@aws-sdk/util-user-agent-node": "3.209.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "fast-xml-parser": "4.0.11",
@@ -9185,9 +8328,9 @@
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.208.0.tgz",
-      "integrity": "sha512-eLwI7rjk3AJj/S8PqRcUi9iBD+cTm1Nzu1CmYyeiwU6YbJLe5/2CrhW1wjkOGleE+aD967U1TWiB18tsx6fj+w==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
+      "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
       "requires": {
         "@aws-sdk/signature-v4": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -9207,11 +8350,11 @@
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.208.0.tgz",
-      "integrity": "sha512-z4Bk42FQefBzS1SZ6/4gsAFE7tQhEoDmSUrFVSDu/9WwvGpFMnFfHLTBhivlcAHjc/eQ/hiWYLnQ8vahqhHl8w==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
+      "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "@aws-sdk/url-parser": "3.208.0",
@@ -9219,56 +8362,57 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.208.0.tgz",
-      "integrity": "sha512-AhsUj4046wMnxrPunNVEuddOIb//KsaicRqucw1Pb/UqszDRO4hYWkw7pL10MPIqjHBwuXYZ3vjDZrIhIWMn7A==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.209.0.tgz",
+      "integrity": "sha512-aszuzkKIg7V+tCcq8RNpr1dAyECXWvJRAvzlmE5ZBYtjHMIX/qVAqSP4sfLNeI/Qagyj7W0TeVA1XVRjkivjYA==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/credential-provider-sso": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.209.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.208.0.tgz",
-      "integrity": "sha512-KYoxlpDzvhw6v0ae0TgIGPP52HJUHQGI3yImhAZZTz0Nh5B0zd2stip+p36sCYRW6V+TJ5mo5minwqDmYe8oXg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.209.0.tgz",
+      "integrity": "sha512-R0kV6B+GxbfdSowf/6eeEAHZC6X7P/IxJ/o/gCuMmAOixge0e6AWVgCvrd0cg0togJHWbmoYSuUyqWPIMxM1Yg==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/credential-provider-ini": "3.208.0",
-        "@aws-sdk/credential-provider-process": "3.208.0",
-        "@aws-sdk/credential-provider-sso": "3.208.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/credential-provider-ini": "3.209.0",
+        "@aws-sdk/credential-provider-process": "3.209.0",
+        "@aws-sdk/credential-provider-sso": "3.209.0",
         "@aws-sdk/credential-provider-web-identity": "3.208.0",
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.208.0.tgz",
-      "integrity": "sha512-ExvFSJB/pVV+/BXIvFR9dgoGxWWnF6uqIw1hfpWCh28UDwsOQdbfUKblMovUfPDBUw67Laqy3mtiY37Jyo/EUQ==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
+      "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
       "requires": {
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.208.0.tgz",
-      "integrity": "sha512-GVUBmSG8eO4oXy5XpslAgVUBimEVBYmyCdwrwED79ey/7NWfkIVt46VZQapWyAJsarKW+VFpx7BYnam9YBR6hA==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.209.0.tgz",
+      "integrity": "sha512-SKzUYOn2EFx58+iU1KihGLtBz9s1jolWUQ6HYxOy4AkWnZVGUt9Vb4mIo6wB07nSSUgYRxOSYn21SKvvBzpc2g==",
       "requires": {
-        "@aws-sdk/client-sso": "3.208.0",
+        "@aws-sdk/client-sso": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
+        "@aws-sdk/token-providers": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }
@@ -9450,11 +8594,11 @@
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.208.0.tgz",
-      "integrity": "sha512-RSbqxZ/oVBY7VvIjwm8ZrpcI4jd+oZZJVXNA2H++J12yEVGNLYOFXZzUatq+Z8ryfuugdsvfMYvVA64qzT8rQw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.209.0.tgz",
+      "integrity": "sha512-ZBWYhTBfdc/bUNB1N4jL8ZW7NmKTkdowbZHTlxtXi8ySzzn+qlD+XosIEbXqrVR9sYxSVC3kwsQvADxHzKGixw==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
         "@aws-sdk/endpoint-cache": "3.208.0",
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -9523,9 +8667,9 @@
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.208.0.tgz",
-      "integrity": "sha512-JAcN2e3PKWGcNX7run/jP6xJ7w2m15a2CpVrfMtka9p/I/3qnqB86jGUs/3Iv04FEqgXq7KTHbFBg8CndsaHEw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
+      "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
       "requires": {
         "@aws-sdk/protocol-http": "3.208.0",
         "@aws-sdk/service-error-classification": "3.208.0",
@@ -9610,12 +8754,12 @@
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.208.0.tgz",
-      "integrity": "sha512-htjs1cDXYXEMwZ1q2vb7wfG3bOW4weWWkKcfT7vqzZKfTXoMH2mPpJIXnPE1PxXerOLXHGUU8qqhfl6LxjlnfQ==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
+      "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
       "requires": {
         "@aws-sdk/property-provider": "3.208.0",
-        "@aws-sdk/shared-ini-file-loader": "3.208.0",
+        "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }
@@ -9675,9 +8819,9 @@
       "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.208.0.tgz",
-      "integrity": "sha512-ZDmwOLNiBKfvtN1M2eG2bItw0+4hKDU/XKqB+yVI9Uo29o4XwtQ4Br7HixTlPYJAavmM1cCch8PVvnwngYAKPA==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
+      "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -9709,9 +8853,9 @@
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.208.0.tgz",
-      "integrity": "sha512-4SGPAs7ZtG9AUYknJNkZTs+ww1cpdcPth5te+R/dN4anUbqtL2qvmbdZJ+8rzdAZKndXu0huKE1OZrR3COLciw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
+      "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
       "requires": {
         "@aws-sdk/middleware-stack": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -9728,17 +8872,6 @@
         "@aws-sdk/shared-ini-file-loader": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
-      },
-      "dependencies": {
-        "@aws-sdk/shared-ini-file-loader": {
-          "version": "3.209.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-          "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-          "requires": {
-            "@aws-sdk/types": "3.208.0",
-            "tslib": "^2.3.1"
-          }
-        }
       }
     },
     "@aws-sdk/types": {
@@ -9768,23 +8901,6 @@
       "version": "3.208.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
       "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.208.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.208.0.tgz",
-      "integrity": "sha512-nR6S6aZqlr//Sy3+2J7G2mn5XG1ELBBTswvbp6kCo5BK9v/kESuzsHC5b6f3xzl/TY4JSG8Aj+h7x+kZHfKwwg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.208.0.tgz",
-      "integrity": "sha512-tCkSexa90loq8yU+BKAX5WIVQGq8IM/DdFhFphQd1azgOIBYxafA/aVw9mDY+to0mq4QRHiUwmUsmzLWEFSDJg==",
       "requires": {
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
@@ -9824,9 +8940,9 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.208.0.tgz",
-      "integrity": "sha512-i4cA074pycou1BPr7axFMiK3iHv+Tzjl/ZiN3Yc0BQDLWC9AQdrNodB4WAKnn4a4fWgA/MadfzKXnW1oltSzIg==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
+      "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
       "requires": {
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
@@ -9835,22 +8951,22 @@
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.208.0.tgz",
-      "integrity": "sha512-y9dENqcmiUb7/D3uwJsE/fV+RZ9CUc/cs4OcofO81sU29xz8Fg/XQarjSdGVZMTnrDd190GXymMcB4qpOYhtPw==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
+      "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.208.0",
-        "@aws-sdk/credential-provider-imds": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/config-resolver": "3.209.0",
+        "@aws-sdk/credential-provider-imds": "3.209.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/property-provider": "3.208.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.208.0.tgz",
-      "integrity": "sha512-FGJA07iEbC883bAaw0qtDrly5Y+1nR3ic+OOzGX2AsSgaeVAc1j8Lgg3br7ofBbr8p81ec6zN4syy4v7V0Wb0A==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.209.0.tgz",
+      "integrity": "sha512-jwraCtWjQ0P4LyIg4qoQRF94mTUg0zFPmicy4v+Dq1V8BBRf6YWa9B10SoIdGIKQXmQvoyahK5OuH5SWKkY2pw==",
       "requires": {
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
@@ -9923,11 +9039,11 @@
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.208.0.tgz",
-      "integrity": "sha512-T7V3TTc+NdcHgITo8yMUDs/qR0wfPjURUrCixHPtqYkqvhoF6YrHUAoCbOcz7SG/Tsm2GgSKAHB4ip9D2QLg4g==",
+      "version": "3.209.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
+      "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.208.0",
+        "@aws-sdk/node-config-provider": "3.209.0",
         "@aws-sdk/types": "3.208.0",
         "tslib": "^2.3.1"
       }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.211.0",
-        "@aws-sdk/client-s3": "^3.211.0",
+        "@aws-sdk/client-s3": "^3.212.0",
         "express": "^4.18.2"
       },
       "devDependencies": {
@@ -235,63 +235,773 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.211.0.tgz",
-      "integrity": "sha512-Wk7bqhhdMtys/dd97ap0GMfJcGzlYrlWsGzK5uNF+TqvOcpZ4NIk7Ui0+NCtSfrM8CajfQRamwPKs0N/8sFIiQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.212.0.tgz",
+      "integrity": "sha512-Z8Q7e6XERVm4MH5dn1L37L51N/GsOQZZJYL3TgUUhA8rOURZRpbjRu2dq9lk/KkRZasSOfzh+tYGu1XDTe4S0A==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.211.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.211.0",
-        "@aws-sdk/eventstream-serde-browser": "3.208.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
-        "@aws-sdk/eventstream-serde-node": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-blob-browser": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/hash-stream-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/md5-js": "3.208.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-expect-continue": "3.208.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-location-constraint": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-s3": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-ssec": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4-multi-region": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/client-sts": "3.212.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-node": "3.212.0",
+        "@aws-sdk/eventstream-serde-browser": "3.212.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.212.0",
+        "@aws-sdk/eventstream-serde-node": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-blob-browser": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/hash-stream-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/md5-js": "3.212.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-expect-continue": "3.212.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-location-constraint": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-sdk-s3": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/middleware-ssec": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4-multi-region": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-stream-browser": "3.208.0",
-        "@aws-sdk/util-stream-node": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-stream-browser": "3.212.0",
+        "@aws-sdk/util-stream-node": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.208.0",
+        "@aws-sdk/util-waiter": "3.212.0",
         "@aws-sdk/xml-builder": "3.201.0",
         "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
+      "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.212.0.tgz",
+      "integrity": "sha512-b9lFI8Uz6YxIzAlS2uq62y5fX097lwcdkiq2N8YN2U7YgHQaKMIFnV8ZqkDdhZi2eUKwhSdUZzQy0tF6en2Ubg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.212.0.tgz",
+      "integrity": "sha512-Co0AU+y9KEAZUraT36ttFZlmwARsr82q2nQji5E8zg3zlUHtqGvMJqxArudz3iOb2E9WRi75MwAQmLO2xEk45A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.212.0.tgz",
+      "integrity": "sha512-Zl8665HT1Do/yfiFEtqEjLkHSkAo5Isg2QU65Kbknj2W2DFj92a1cRvMlHanDLxlpuoryGP9/u1efYZeWeIdlg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-node": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-sdk-sts": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.212.0.tgz",
+      "integrity": "sha512-hIP/Izpv6GCsDTnHCd/X9Ro7Mw5le+gr2VbkZHWR0c8+3xZWp8N5S0QnUBogF3Dv2KwPbmHP+bs/vqqo3miUjQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.212.0.tgz",
+      "integrity": "sha512-HNYoqetLqTxwl0Grl4ez8Dx3I3hJfskxH2PTHYI1/iAqrY/gSB2oBOusvBeksbYrScnQM2IGqEcMJ4lzGLOH+w==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.212.0.tgz",
+      "integrity": "sha512-Bg7cX2N5pJ//ft3Y8HWtpDSEMMgRTNMaNlIvTlDbAKYp7HBZRWSf9ZJnz2slT7qbyaJyRP5pSJC4XRm83g4leA==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.212.0.tgz",
+      "integrity": "sha512-H7qRIP8qV7tRrCSJx2p5oQVMJASQWZUmi4l699hDMejmCO/m4pUMQFmWn2FXtZv8gTfzlkmp3wMixD5jnfL7pw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.212.0",
+        "@aws-sdk/credential-provider-imds": "3.212.0",
+        "@aws-sdk/credential-provider-sso": "3.212.0",
+        "@aws-sdk/credential-provider-web-identity": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.212.0.tgz",
+      "integrity": "sha512-T44hoU3GCYHS+4GDVs7S/v2bBHmmYpnPayQsYXhDElQKXP0cFzQ78F8et4IU5lM94hwK+ISRQPrKaq4p77evkw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.212.0",
+        "@aws-sdk/credential-provider-imds": "3.212.0",
+        "@aws-sdk/credential-provider-ini": "3.212.0",
+        "@aws-sdk/credential-provider-process": "3.212.0",
+        "@aws-sdk/credential-provider-sso": "3.212.0",
+        "@aws-sdk/credential-provider-web-identity": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.212.0.tgz",
+      "integrity": "sha512-bGaVKSm5Tf5VZtlM2V6k+M9nSKzlb14ldCcH0PGGMaK/dqnEJDVSxXPu3fWyomaxbLt7Is3AUMh6L2bq3kuXyA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.212.0.tgz",
+      "integrity": "sha512-OGatVUnWLp7PePs2H2RyYmTrwurl0tAfW+LWfVAPgYyvi2RQgTmSK5LJ3pXKxz3TvaSHkCvsT0NWNqdWY+iKWQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/token-providers": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.212.0.tgz",
+      "integrity": "sha512-zPF3KiVT14aeu4cRyEUelAJEAzFp++9ULLigQXhKBbFYaiOZMAHKRASO/WUK1ixYBC+ax4G1rbihLfQimXMtVA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
+      "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/querystring-builder": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/hash-node": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.212.0.tgz",
+      "integrity": "sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.212.0.tgz",
+      "integrity": "sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.212.0.tgz",
+      "integrity": "sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.212.0.tgz",
+      "integrity": "sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.212.0.tgz",
+      "integrity": "sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.212.0.tgz",
+      "integrity": "sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz",
+      "integrity": "sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.212.0.tgz",
+      "integrity": "sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/service-error-classification": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-middleware": "3.212.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.212.0.tgz",
+      "integrity": "sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.212.0.tgz",
+      "integrity": "sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.212.0.tgz",
+      "integrity": "sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-middleware": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.212.0.tgz",
+      "integrity": "sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.212.0.tgz",
+      "integrity": "sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz",
+      "integrity": "sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
+      "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/querystring-builder": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/property-provider": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.212.0.tgz",
+      "integrity": "sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+      "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.212.0.tgz",
+      "integrity": "sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.212.0.tgz",
+      "integrity": "sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.212.0.tgz",
+      "integrity": "sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
+      "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.212.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.212.0.tgz",
+      "integrity": "sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.212.0.tgz",
+      "integrity": "sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/shared-ini-file-loader": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/url-parser": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.212.0.tgz",
+      "integrity": "sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.212.0.tgz",
+      "integrity": "sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.212.0.tgz",
+      "integrity": "sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-imds": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/property-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.212.0.tgz",
+      "integrity": "sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
+      "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.212.0.tgz",
+      "integrity": "sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz",
+      "integrity": "sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.212.0.tgz",
+      "integrity": "sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
@@ -565,63 +1275,103 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-codec": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.208.0.tgz",
-      "integrity": "sha512-CT5+DV92xvGpGivFCcg/Hb2HOEad52XMVVgxHkgwnsy8Z+S+mk7xON3+BG0U8+TCQXTlq3pDs05iJ6EPeBs2Wg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.212.0.tgz",
+      "integrity": "sha512-XxhV+8BmRGxLzibKKnYCaPXfGPiFiu9pz9h5sPGA7KH3Ax/dKfVUK1QH7FhOQTNKYoSe093yLqRgb9+FYnJtjQ==",
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@aws-sdk/eventstream-codec/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.208.0.tgz",
-      "integrity": "sha512-8nK/geIqWTuSJODTQ2dXhEuLhjpdXWm+ZU5iB76B7RoDXFGL+iX2VS9lsSNoxEcFQPx0iJ1OgV88JbXk13GmTg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.212.0.tgz",
+      "integrity": "sha512-rHcPtDzgxQbbAHEtbmgO/Z3PFLevxiu1Ev1YP6Rdb9XTWz/ke2AggF+4SOkNAGuQCDQ/E5kC5RG7E+wC9rEj3g==",
       "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/eventstream-serde-universal": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.208.0.tgz",
-      "integrity": "sha512-pmq52299XfBwx72hVO3+qXH10VTGw9Ef6HmdQGhSAIs91F6pFWNZdkdGtEtJHBooGf93rtGxpJuk6Io+XhynCw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.212.0.tgz",
+      "integrity": "sha512-/ZHYdIbgCsZemb5zQ2yICjpB2aVUkfIgKXimnwbqBbynuo24P4mrd38Rmos8xbIJ9IEKmcMsyZLqttRCAZKSwg==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.208.0.tgz",
-      "integrity": "sha512-N1nr1cIyyroGsqw7c02JESZP5EC8iN14VX9WwyZidlmPwtcTuyDgSzw1EYfC+QQQDW2nHkYtGfpweBNRlic6+g==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.212.0.tgz",
+      "integrity": "sha512-yHvWK+ZWHVDIumFrQOJRuM1+HON5puYOEwBvZkUs7dK7M7gXhpNoASqL662fI2oWEv1rCLSV7rmo/5UxLg4Pdw==",
       "dependencies": {
-        "@aws-sdk/eventstream-serde-universal": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/eventstream-serde-universal": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/eventstream-serde-node/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.208.0.tgz",
-      "integrity": "sha512-On8s1akmiUMqZIQ5Uj/F3Dzy6BkA4EzMnDsxDTVMRWKa3WQ4E574yvayQY/i6Z2TL7QvFD5sYT10iE5yPCy/Mg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.212.0.tgz",
+      "integrity": "sha512-5+ZbYwr1ytmOUTXh6U6skDVAzmicm3rlYy72tO7CS3UGPhyrbi9MghiulNNrc9FUpQ1VAtczCnOuv0rLCQB1IA==",
       "dependencies": {
-        "@aws-sdk/eventstream-codec": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/eventstream-codec": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -639,14 +1389,22 @@
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.208.0.tgz",
-      "integrity": "sha512-Mj9dOA2cLk3WvYgcK0myf4AGqXWi3IDcbbj6oFWeBYQ6tGolehzUeVHQH8inE0iRZSbDGXUwWhoa8vlyciYmew==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.212.0.tgz",
+      "integrity": "sha512-8ES7xUqosE+/TTyCsWQ4Qg1O/WMfk4/smi9SnrVBeYjRsPYXndr2JNHJDdey91rzG0aqvaEjlQKK92Rcul+MMg==",
       "dependencies": {
         "@aws-sdk/chunked-blob-reader": "3.188.0",
         "@aws-sdk/chunked-blob-reader-native": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-blob-browser/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
@@ -663,13 +1421,21 @@
       }
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.208.0.tgz",
-      "integrity": "sha512-gMmlzYsLXVt8ehibhTvQWHsPGR3RHytPOP33Jk/YLKyELnUvfn27396JgRgMv/mihIgMq7J2ZEbKkVRvx+FKZw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.212.0.tgz",
+      "integrity": "sha512-PnQ+EO8OKWvPSF4UQRRyYhsblFJA1DbebhPGOzfJ3tUJn0+2bg2BsTJnQ4wlKfuyTx0sxWHiu5YBgCWyF0HkEQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-stream-node/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -695,27 +1461,55 @@
       }
     },
     "node_modules/@aws-sdk/md5-js": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.208.0.tgz",
-      "integrity": "sha512-1yaf3gtXDJmWDMwU9gyswTGa1jG4cEFDydk8G2vkHPpSOrgbxLWtX31Hwnrxdw3FFJDasjLR99OylqHOh6D2lw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.212.0.tgz",
+      "integrity": "sha512-dPK6SzMyNSumD+fpIEoMzMgwlceETgCCCP87NEkyjdHoCcgSlQPE74noPDLU6qsogJJzz5W1Yt9kzX7HODm92g==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@aws-sdk/md5-js/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.209.0.tgz",
-      "integrity": "sha512-H7yKwR7ephdXWTfHjqs9Opc9hpdrHnRpWWcpeUcDVKK5G+8yb99y0XhJx0n43v+bzk4uo91mAg3eBdTX0AgHmA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.212.0.tgz",
+      "integrity": "sha512-VNlkPL3B1UMvvoWWQZa12Sn0irn8PUdG9/PYDByEEOs0nap3MFRlRIC4KH7uEeLhyDGJ2ZeEzJjQenv1zfQM1g==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "@aws-sdk/util-config-provider": "3.208.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -767,30 +1561,70 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.208.0.tgz",
-      "integrity": "sha512-T/oTNwmJCbv36BidaE8GYY53dXnKKO6GkExp5RLcTeNx7ZGSarV5j+LMeTYPkx6Ha4IkMMIlz8DB4B7rb9bpRQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.212.0.tgz",
+      "integrity": "sha512-nFZ5Eci5Rtb0WTCzhL8vMCbsm4+hdMSVCeid2ixJU6M0Ju7V5wgXHcLT2n008juhnNfBeygm2eHBFoqIwfRsRg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.208.0.tgz",
-      "integrity": "sha512-5VrjGKZ2PCp6+VtyWzVintsHA6J2n0gsMyRCQGMn2LC4+22TIUQIyYaIpVp0SzbJveV7z+5iGnxTMYlpYApr3Q==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.212.0.tgz",
+      "integrity": "sha512-OS9Sxit+jdOa5k3ukpEO9+6GhqcLjve6ftX8M2UZg5hEvMrTA/a4O0sk0SeHdi02HgOZZqtMAwbBTUfFoEZorQ==",
       "dependencies": {
         "@aws-crypto/crc32": "2.0.0",
         "@aws-crypto/crc32c": "2.0.0",
         "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -809,13 +1643,21 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.208.0.tgz",
-      "integrity": "sha512-TNU8/NibMyi97qf7/VL1CFIijY6mS9GP7dgN+J6BiMOLS3pJLCmFd5BiaZNsdhOnepQ3jnr+zpVxmfn3D8miVA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.212.0.tgz",
+      "integrity": "sha512-R6MLIQaHteW4eWY5Fh86MKRUG3RJZjvWJMNWyCp9guAOP4fyl7ODCfJn3x8Z764bS82fNsLPOp8/HNQKycMTHQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -862,16 +1704,36 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.209.0.tgz",
-      "integrity": "sha512-vmWKoWbgmO+GKVdu4jw5fk/x0thBYBkx349jS4jGB81Y8erv5V8M5rautcvb1oSTW+oh5Q8ZW07SgaPaLfjsAw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.212.0.tgz",
+      "integrity": "sha512-pf7vOcZYCqYakxxbVgv6sGvEnvaXqpv0fo2zcO6vLrNjXjBSahMHUpnG3DHdR57auDdeaIevWSkx2hJpAMMhFg==",
       "dependencies": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -921,13 +1783,21 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.208.0.tgz",
-      "integrity": "sha512-Kx3Z8RQu/tHTDTBQPXT3SyvsW8KxoNPBxP2d84Gugb6Pj766fZlYj7qOqWTSx+aCOSOIHcPjxilgTNJ6VBbJmA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.212.0.tgz",
+      "integrity": "sha512-LmBbOgwwLMRatYsYAnasDmCEb7O11LkQKapFgj5Woi3qCW6U6TKP5+ucjou35AAPgZhwcaYDRK2nHcEPH1xGiA==",
       "dependencies": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -1071,13 +1941,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.208.0.tgz",
-      "integrity": "sha512-7CZtIxj+hlBvGKjz/8BweLIEdTZdtSiyH9RuW2Oue25RF3YPtKpwanlV7obk/+UIVh36oe1EWaXEBbS0h68GhA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.212.0.tgz",
+      "integrity": "sha512-d/L2dkpxBtVBFQGc3RLkoOrPj7TWY8eQM4enD56tBAOwgMdrl42hYHmbrAeTJ3Q6Seyht71XIjez+o97qF7QFg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "tslib": "^2.3.1"
       },
@@ -1091,6 +1961,53 @@
         "@aws-sdk/signature-v4-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
+      "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.212.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/util-middleware": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
+      "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
@@ -1280,28 +2197,133 @@
       }
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.208.0.tgz",
-      "integrity": "sha512-zKAwaMn7tLLTA1uZFL0Ynomxu/EVeUa2VKxB+y87g3hHZmC11QQ5rOiNTnvYzy6w3BsssWNYzazom3jNhpWvtQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.212.0.tgz",
+      "integrity": "sha512-WuWZdSeqDD8IQq78rstJX/bdWtdEtnYkfIm79xa41YB8WTuynz+ijg26YcXRrq5JAtWCEw+2BUceyV+7dYWqrg==",
       "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.208.0.tgz",
-      "integrity": "sha512-2/gB8QchikmrxOBNVytviX8j1H6GZg/TKdUiUlLg5/x7I2EMlaKZK3FI7In80gqwoG6C7h8NwEIvpfmbhl7gAw==",
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
+      "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
       "dependencies": {
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/querystring-builder": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+      "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.212.0.tgz",
+      "integrity": "sha512-Nmtg1H/Xgbn+j4tq4sq8l9YkzFtajWp+Wrl1maoNCzcd9xGtUkfQVT35XXvveIoAZZe5fW/kM1zrxINjjlL/6w==",
+      "dependencies": {
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
+      "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
+      "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/querystring-builder": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+      "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+      "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/@aws-sdk/types": {
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+      "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -8146,64 +9168,642 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.211.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.211.0.tgz",
-      "integrity": "sha512-Wk7bqhhdMtys/dd97ap0GMfJcGzlYrlWsGzK5uNF+TqvOcpZ4NIk7Ui0+NCtSfrM8CajfQRamwPKs0N/8sFIiQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.212.0.tgz",
+      "integrity": "sha512-Z8Q7e6XERVm4MH5dn1L37L51N/GsOQZZJYL3TgUUhA8rOURZRpbjRu2dq9lk/KkRZasSOfzh+tYGu1XDTe4S0A==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.211.0",
-        "@aws-sdk/config-resolver": "3.209.0",
-        "@aws-sdk/credential-provider-node": "3.211.0",
-        "@aws-sdk/eventstream-serde-browser": "3.208.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.208.0",
-        "@aws-sdk/eventstream-serde-node": "3.208.0",
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/hash-blob-browser": "3.208.0",
-        "@aws-sdk/hash-node": "3.208.0",
-        "@aws-sdk/hash-stream-node": "3.208.0",
-        "@aws-sdk/invalid-dependency": "3.208.0",
-        "@aws-sdk/md5-js": "3.208.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
-        "@aws-sdk/middleware-content-length": "3.208.0",
-        "@aws-sdk/middleware-endpoint": "3.208.0",
-        "@aws-sdk/middleware-expect-continue": "3.208.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.208.0",
-        "@aws-sdk/middleware-host-header": "3.208.0",
-        "@aws-sdk/middleware-location-constraint": "3.208.0",
-        "@aws-sdk/middleware-logger": "3.208.0",
-        "@aws-sdk/middleware-recursion-detection": "3.208.0",
-        "@aws-sdk/middleware-retry": "3.209.0",
-        "@aws-sdk/middleware-sdk-s3": "3.209.0",
-        "@aws-sdk/middleware-serde": "3.208.0",
-        "@aws-sdk/middleware-signing": "3.208.0",
-        "@aws-sdk/middleware-ssec": "3.208.0",
-        "@aws-sdk/middleware-stack": "3.208.0",
-        "@aws-sdk/middleware-user-agent": "3.208.0",
-        "@aws-sdk/node-config-provider": "3.209.0",
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4-multi-region": "3.208.0",
-        "@aws-sdk/smithy-client": "3.209.0",
-        "@aws-sdk/types": "3.208.0",
-        "@aws-sdk/url-parser": "3.208.0",
+        "@aws-sdk/client-sts": "3.212.0",
+        "@aws-sdk/config-resolver": "3.212.0",
+        "@aws-sdk/credential-provider-node": "3.212.0",
+        "@aws-sdk/eventstream-serde-browser": "3.212.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.212.0",
+        "@aws-sdk/eventstream-serde-node": "3.212.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/hash-blob-browser": "3.212.0",
+        "@aws-sdk/hash-node": "3.212.0",
+        "@aws-sdk/hash-stream-node": "3.212.0",
+        "@aws-sdk/invalid-dependency": "3.212.0",
+        "@aws-sdk/md5-js": "3.212.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.212.0",
+        "@aws-sdk/middleware-content-length": "3.212.0",
+        "@aws-sdk/middleware-endpoint": "3.212.0",
+        "@aws-sdk/middleware-expect-continue": "3.212.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.212.0",
+        "@aws-sdk/middleware-host-header": "3.212.0",
+        "@aws-sdk/middleware-location-constraint": "3.212.0",
+        "@aws-sdk/middleware-logger": "3.212.0",
+        "@aws-sdk/middleware-recursion-detection": "3.212.0",
+        "@aws-sdk/middleware-retry": "3.212.0",
+        "@aws-sdk/middleware-sdk-s3": "3.212.0",
+        "@aws-sdk/middleware-serde": "3.212.0",
+        "@aws-sdk/middleware-signing": "3.212.0",
+        "@aws-sdk/middleware-ssec": "3.212.0",
+        "@aws-sdk/middleware-stack": "3.212.0",
+        "@aws-sdk/middleware-user-agent": "3.212.0",
+        "@aws-sdk/node-config-provider": "3.212.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4-multi-region": "3.212.0",
+        "@aws-sdk/smithy-client": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
+        "@aws-sdk/url-parser": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-body-length-browser": "3.188.0",
         "@aws-sdk/util-body-length-node": "3.208.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-        "@aws-sdk/util-defaults-mode-node": "3.209.0",
-        "@aws-sdk/util-endpoints": "3.211.0",
-        "@aws-sdk/util-stream-browser": "3.208.0",
-        "@aws-sdk/util-stream-node": "3.208.0",
-        "@aws-sdk/util-user-agent-browser": "3.208.0",
-        "@aws-sdk/util-user-agent-node": "3.209.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+        "@aws-sdk/util-defaults-mode-node": "3.212.0",
+        "@aws-sdk/util-endpoints": "3.212.0",
+        "@aws-sdk/util-stream-browser": "3.212.0",
+        "@aws-sdk/util-stream-node": "3.212.0",
+        "@aws-sdk/util-user-agent-browser": "3.212.0",
+        "@aws-sdk/util-user-agent-node": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
-        "@aws-sdk/util-waiter": "3.208.0",
+        "@aws-sdk/util-waiter": "3.212.0",
         "@aws-sdk/xml-builder": "3.201.0",
         "fast-xml-parser": "4.0.11",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
+          "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.212.0.tgz",
+          "integrity": "sha512-b9lFI8Uz6YxIzAlS2uq62y5fX097lwcdkiq2N8YN2U7YgHQaKMIFnV8ZqkDdhZi2eUKwhSdUZzQy0tF6en2Ubg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.212.0",
+            "@aws-sdk/fetch-http-handler": "3.212.0",
+            "@aws-sdk/hash-node": "3.212.0",
+            "@aws-sdk/invalid-dependency": "3.212.0",
+            "@aws-sdk/middleware-content-length": "3.212.0",
+            "@aws-sdk/middleware-endpoint": "3.212.0",
+            "@aws-sdk/middleware-host-header": "3.212.0",
+            "@aws-sdk/middleware-logger": "3.212.0",
+            "@aws-sdk/middleware-recursion-detection": "3.212.0",
+            "@aws-sdk/middleware-retry": "3.212.0",
+            "@aws-sdk/middleware-serde": "3.212.0",
+            "@aws-sdk/middleware-stack": "3.212.0",
+            "@aws-sdk/middleware-user-agent": "3.212.0",
+            "@aws-sdk/node-config-provider": "3.212.0",
+            "@aws-sdk/node-http-handler": "3.212.0",
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/smithy-client": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/url-parser": "3.212.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+            "@aws-sdk/util-defaults-mode-node": "3.212.0",
+            "@aws-sdk/util-endpoints": "3.212.0",
+            "@aws-sdk/util-user-agent-browser": "3.212.0",
+            "@aws-sdk/util-user-agent-node": "3.212.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso-oidc": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.212.0.tgz",
+          "integrity": "sha512-Co0AU+y9KEAZUraT36ttFZlmwARsr82q2nQji5E8zg3zlUHtqGvMJqxArudz3iOb2E9WRi75MwAQmLO2xEk45A==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.212.0",
+            "@aws-sdk/fetch-http-handler": "3.212.0",
+            "@aws-sdk/hash-node": "3.212.0",
+            "@aws-sdk/invalid-dependency": "3.212.0",
+            "@aws-sdk/middleware-content-length": "3.212.0",
+            "@aws-sdk/middleware-endpoint": "3.212.0",
+            "@aws-sdk/middleware-host-header": "3.212.0",
+            "@aws-sdk/middleware-logger": "3.212.0",
+            "@aws-sdk/middleware-recursion-detection": "3.212.0",
+            "@aws-sdk/middleware-retry": "3.212.0",
+            "@aws-sdk/middleware-serde": "3.212.0",
+            "@aws-sdk/middleware-stack": "3.212.0",
+            "@aws-sdk/middleware-user-agent": "3.212.0",
+            "@aws-sdk/node-config-provider": "3.212.0",
+            "@aws-sdk/node-http-handler": "3.212.0",
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/smithy-client": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/url-parser": "3.212.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+            "@aws-sdk/util-defaults-mode-node": "3.212.0",
+            "@aws-sdk/util-endpoints": "3.212.0",
+            "@aws-sdk/util-user-agent-browser": "3.212.0",
+            "@aws-sdk/util-user-agent-node": "3.212.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.212.0.tgz",
+          "integrity": "sha512-Zl8665HT1Do/yfiFEtqEjLkHSkAo5Isg2QU65Kbknj2W2DFj92a1cRvMlHanDLxlpuoryGP9/u1efYZeWeIdlg==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.212.0",
+            "@aws-sdk/credential-provider-node": "3.212.0",
+            "@aws-sdk/fetch-http-handler": "3.212.0",
+            "@aws-sdk/hash-node": "3.212.0",
+            "@aws-sdk/invalid-dependency": "3.212.0",
+            "@aws-sdk/middleware-content-length": "3.212.0",
+            "@aws-sdk/middleware-endpoint": "3.212.0",
+            "@aws-sdk/middleware-host-header": "3.212.0",
+            "@aws-sdk/middleware-logger": "3.212.0",
+            "@aws-sdk/middleware-recursion-detection": "3.212.0",
+            "@aws-sdk/middleware-retry": "3.212.0",
+            "@aws-sdk/middleware-sdk-sts": "3.212.0",
+            "@aws-sdk/middleware-serde": "3.212.0",
+            "@aws-sdk/middleware-signing": "3.212.0",
+            "@aws-sdk/middleware-stack": "3.212.0",
+            "@aws-sdk/middleware-user-agent": "3.212.0",
+            "@aws-sdk/node-config-provider": "3.212.0",
+            "@aws-sdk/node-http-handler": "3.212.0",
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/smithy-client": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/url-parser": "3.212.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "@aws-sdk/util-body-length-browser": "3.188.0",
+            "@aws-sdk/util-body-length-node": "3.208.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+            "@aws-sdk/util-defaults-mode-node": "3.212.0",
+            "@aws-sdk/util-endpoints": "3.212.0",
+            "@aws-sdk/util-user-agent-browser": "3.212.0",
+            "@aws-sdk/util-user-agent-node": "3.212.0",
+            "@aws-sdk/util-utf8-browser": "3.188.0",
+            "@aws-sdk/util-utf8-node": "3.208.0",
+            "fast-xml-parser": "4.0.11",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.212.0.tgz",
+          "integrity": "sha512-hIP/Izpv6GCsDTnHCd/X9Ro7Mw5le+gr2VbkZHWR0c8+3xZWp8N5S0QnUBogF3Dv2KwPbmHP+bs/vqqo3miUjQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.212.0.tgz",
+          "integrity": "sha512-HNYoqetLqTxwl0Grl4ez8Dx3I3hJfskxH2PTHYI1/iAqrY/gSB2oBOusvBeksbYrScnQM2IGqEcMJ4lzGLOH+w==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.212.0.tgz",
+          "integrity": "sha512-Bg7cX2N5pJ//ft3Y8HWtpDSEMMgRTNMaNlIvTlDbAKYp7HBZRWSf9ZJnz2slT7qbyaJyRP5pSJC4XRm83g4leA==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.212.0",
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/url-parser": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.212.0.tgz",
+          "integrity": "sha512-H7qRIP8qV7tRrCSJx2p5oQVMJASQWZUmi4l699hDMejmCO/m4pUMQFmWn2FXtZv8gTfzlkmp3wMixD5jnfL7pw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.212.0",
+            "@aws-sdk/credential-provider-imds": "3.212.0",
+            "@aws-sdk/credential-provider-sso": "3.212.0",
+            "@aws-sdk/credential-provider-web-identity": "3.212.0",
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/shared-ini-file-loader": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.212.0.tgz",
+          "integrity": "sha512-T44hoU3GCYHS+4GDVs7S/v2bBHmmYpnPayQsYXhDElQKXP0cFzQ78F8et4IU5lM94hwK+ISRQPrKaq4p77evkw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.212.0",
+            "@aws-sdk/credential-provider-imds": "3.212.0",
+            "@aws-sdk/credential-provider-ini": "3.212.0",
+            "@aws-sdk/credential-provider-process": "3.212.0",
+            "@aws-sdk/credential-provider-sso": "3.212.0",
+            "@aws-sdk/credential-provider-web-identity": "3.212.0",
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/shared-ini-file-loader": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.212.0.tgz",
+          "integrity": "sha512-bGaVKSm5Tf5VZtlM2V6k+M9nSKzlb14ldCcH0PGGMaK/dqnEJDVSxXPu3fWyomaxbLt7Is3AUMh6L2bq3kuXyA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/shared-ini-file-loader": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.212.0.tgz",
+          "integrity": "sha512-OGatVUnWLp7PePs2H2RyYmTrwurl0tAfW+LWfVAPgYyvi2RQgTmSK5LJ3pXKxz3TvaSHkCvsT0NWNqdWY+iKWQ==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.212.0",
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/shared-ini-file-loader": "3.212.0",
+            "@aws-sdk/token-providers": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.212.0.tgz",
+          "integrity": "sha512-zPF3KiVT14aeu4cRyEUelAJEAzFp++9ULLigQXhKBbFYaiOZMAHKRASO/WUK1ixYBC+ax4G1rbihLfQimXMtVA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
+          "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/querystring-builder": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.212.0.tgz",
+          "integrity": "sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-buffer-from": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.212.0.tgz",
+          "integrity": "sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.212.0.tgz",
+          "integrity": "sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-endpoint": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.212.0.tgz",
+          "integrity": "sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==",
+          "requires": {
+            "@aws-sdk/middleware-serde": "3.212.0",
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/signature-v4": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/url-parser": "3.212.0",
+            "@aws-sdk/util-config-provider": "3.208.0",
+            "@aws-sdk/util-middleware": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.212.0.tgz",
+          "integrity": "sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.212.0.tgz",
+          "integrity": "sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz",
+          "integrity": "sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.212.0.tgz",
+          "integrity": "sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/service-error-classification": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-middleware": "3.212.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.212.0.tgz",
+          "integrity": "sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.212.0",
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/signature-v4": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.212.0.tgz",
+          "integrity": "sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.212.0.tgz",
+          "integrity": "sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/signature-v4": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-middleware": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.212.0.tgz",
+          "integrity": "sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.212.0.tgz",
+          "integrity": "sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz",
+          "integrity": "sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/shared-ini-file-loader": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
+          "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.212.0",
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/querystring-builder": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.212.0.tgz",
+          "integrity": "sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+          "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.212.0.tgz",
+          "integrity": "sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.212.0.tgz",
+          "integrity": "sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.212.0.tgz",
+          "integrity": "sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
+          "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.212.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.212.0.tgz",
+          "integrity": "sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/token-providers": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.212.0.tgz",
+          "integrity": "sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==",
+          "requires": {
+            "@aws-sdk/client-sso-oidc": "3.212.0",
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/shared-ini-file-loader": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.212.0.tgz",
+          "integrity": "sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.212.0.tgz",
+          "integrity": "sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.212.0.tgz",
+          "integrity": "sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.212.0",
+            "@aws-sdk/credential-provider-imds": "3.212.0",
+            "@aws-sdk/node-config-provider": "3.212.0",
+            "@aws-sdk/property-provider": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-endpoints": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.212.0.tgz",
+          "integrity": "sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
+          "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.212.0.tgz",
+          "integrity": "sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz",
+          "integrity": "sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.212.0.tgz",
+          "integrity": "sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso": {
@@ -8437,53 +10037,88 @@
       }
     },
     "@aws-sdk/eventstream-codec": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.208.0.tgz",
-      "integrity": "sha512-CT5+DV92xvGpGivFCcg/Hb2HOEad52XMVVgxHkgwnsy8Z+S+mk7xON3+BG0U8+TCQXTlq3pDs05iJ6EPeBs2Wg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.212.0.tgz",
+      "integrity": "sha512-XxhV+8BmRGxLzibKKnYCaPXfGPiFiu9pz9h5sPGA7KH3Ax/dKfVUK1QH7FhOQTNKYoSe093yLqRgb9+FYnJtjQ==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.208.0.tgz",
-      "integrity": "sha512-8nK/geIqWTuSJODTQ2dXhEuLhjpdXWm+ZU5iB76B7RoDXFGL+iX2VS9lsSNoxEcFQPx0iJ1OgV88JbXk13GmTg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.212.0.tgz",
+      "integrity": "sha512-rHcPtDzgxQbbAHEtbmgO/Z3PFLevxiu1Ev1YP6Rdb9XTWz/ke2AggF+4SOkNAGuQCDQ/E5kC5RG7E+wC9rEj3g==",
       "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/eventstream-serde-universal": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.208.0.tgz",
-      "integrity": "sha512-pmq52299XfBwx72hVO3+qXH10VTGw9Ef6HmdQGhSAIs91F6pFWNZdkdGtEtJHBooGf93rtGxpJuk6Io+XhynCw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.212.0.tgz",
+      "integrity": "sha512-/ZHYdIbgCsZemb5zQ2yICjpB2aVUkfIgKXimnwbqBbynuo24P4mrd38Rmos8xbIJ9IEKmcMsyZLqttRCAZKSwg==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/eventstream-serde-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.208.0.tgz",
-      "integrity": "sha512-N1nr1cIyyroGsqw7c02JESZP5EC8iN14VX9WwyZidlmPwtcTuyDgSzw1EYfC+QQQDW2nHkYtGfpweBNRlic6+g==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.212.0.tgz",
+      "integrity": "sha512-yHvWK+ZWHVDIumFrQOJRuM1+HON5puYOEwBvZkUs7dK7M7gXhpNoASqL662fI2oWEv1rCLSV7rmo/5UxLg4Pdw==",
       "requires": {
-        "@aws-sdk/eventstream-serde-universal": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/eventstream-serde-universal": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.208.0.tgz",
-      "integrity": "sha512-On8s1akmiUMqZIQ5Uj/F3Dzy6BkA4EzMnDsxDTVMRWKa3WQ4E574yvayQY/i6Z2TL7QvFD5sYT10iE5yPCy/Mg==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.212.0.tgz",
+      "integrity": "sha512-5+ZbYwr1ytmOUTXh6U6skDVAzmicm3rlYy72tO7CS3UGPhyrbi9MghiulNNrc9FUpQ1VAtczCnOuv0rLCQB1IA==",
       "requires": {
-        "@aws-sdk/eventstream-codec": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/eventstream-codec": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/fetch-http-handler": {
@@ -8499,14 +10134,21 @@
       }
     },
     "@aws-sdk/hash-blob-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.208.0.tgz",
-      "integrity": "sha512-Mj9dOA2cLk3WvYgcK0myf4AGqXWi3IDcbbj6oFWeBYQ6tGolehzUeVHQH8inE0iRZSbDGXUwWhoa8vlyciYmew==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.212.0.tgz",
+      "integrity": "sha512-8ES7xUqosE+/TTyCsWQ4Qg1O/WMfk4/smi9SnrVBeYjRsPYXndr2JNHJDdey91rzG0aqvaEjlQKK92Rcul+MMg==",
       "requires": {
         "@aws-sdk/chunked-blob-reader": "3.188.0",
         "@aws-sdk/chunked-blob-reader-native": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/hash-node": {
@@ -8520,12 +10162,19 @@
       }
     },
     "@aws-sdk/hash-stream-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.208.0.tgz",
-      "integrity": "sha512-gMmlzYsLXVt8ehibhTvQWHsPGR3RHytPOP33Jk/YLKyELnUvfn27396JgRgMv/mihIgMq7J2ZEbKkVRvx+FKZw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.212.0.tgz",
+      "integrity": "sha512-PnQ+EO8OKWvPSF4UQRRyYhsblFJA1DbebhPGOzfJ3tUJn0+2bg2BsTJnQ4wlKfuyTx0sxWHiu5YBgCWyF0HkEQ==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/invalid-dependency": {
@@ -8546,26 +10195,49 @@
       }
     },
     "@aws-sdk/md5-js": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.208.0.tgz",
-      "integrity": "sha512-1yaf3gtXDJmWDMwU9gyswTGa1jG4cEFDydk8G2vkHPpSOrgbxLWtX31Hwnrxdw3FFJDasjLR99OylqHOh6D2lw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.212.0.tgz",
+      "integrity": "sha512-dPK6SzMyNSumD+fpIEoMzMgwlceETgCCCP87NEkyjdHoCcgSlQPE74noPDLU6qsogJJzz5W1Yt9kzX7HODm92g==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "@aws-sdk/util-utf8-node": "3.208.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.209.0.tgz",
-      "integrity": "sha512-H7yKwR7ephdXWTfHjqs9Opc9hpdrHnRpWWcpeUcDVKK5G+8yb99y0XhJx0n43v+bzk4uo91mAg3eBdTX0AgHmA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.212.0.tgz",
+      "integrity": "sha512-VNlkPL3B1UMvvoWWQZa12Sn0irn8PUdG9/PYDByEEOs0nap3MFRlRIC4KH7uEeLhyDGJ2ZeEzJjQenv1zfQM1g==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "@aws-sdk/util-config-provider": "3.208.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/middleware-content-length": {
@@ -8606,26 +10278,58 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.208.0.tgz",
-      "integrity": "sha512-T/oTNwmJCbv36BidaE8GYY53dXnKKO6GkExp5RLcTeNx7ZGSarV5j+LMeTYPkx6Ha4IkMMIlz8DB4B7rb9bpRQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.212.0.tgz",
+      "integrity": "sha512-nFZ5Eci5Rtb0WTCzhL8vMCbsm4+hdMSVCeid2ixJU6M0Ju7V5wgXHcLT2n008juhnNfBeygm2eHBFoqIwfRsRg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.208.0.tgz",
-      "integrity": "sha512-5VrjGKZ2PCp6+VtyWzVintsHA6J2n0gsMyRCQGMn2LC4+22TIUQIyYaIpVp0SzbJveV7z+5iGnxTMYlpYApr3Q==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.212.0.tgz",
+      "integrity": "sha512-OS9Sxit+jdOa5k3ukpEO9+6GhqcLjve6ftX8M2UZg5hEvMrTA/a4O0sk0SeHdi02HgOZZqtMAwbBTUfFoEZorQ==",
       "requires": {
         "@aws-crypto/crc32": "2.0.0",
         "@aws-crypto/crc32c": "2.0.0",
         "@aws-sdk/is-array-buffer": "3.201.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/middleware-host-header": {
@@ -8639,12 +10343,19 @@
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.208.0.tgz",
-      "integrity": "sha512-TNU8/NibMyi97qf7/VL1CFIijY6mS9GP7dgN+J6BiMOLS3pJLCmFd5BiaZNsdhOnepQ3jnr+zpVxmfn3D8miVA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.212.0.tgz",
+      "integrity": "sha512-R6MLIQaHteW4eWY5Fh86MKRUG3RJZjvWJMNWyCp9guAOP4fyl7ODCfJn3x8Z764bS82fNsLPOp8/HNQKycMTHQ==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/middleware-logger": {
@@ -8680,15 +10391,31 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.209.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.209.0.tgz",
-      "integrity": "sha512-vmWKoWbgmO+GKVdu4jw5fk/x0thBYBkx349jS4jGB81Y8erv5V8M5rautcvb1oSTW+oh5Q8ZW07SgaPaLfjsAw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.212.0.tgz",
+      "integrity": "sha512-pf7vOcZYCqYakxxbVgv6sGvEnvaXqpv0fo2zcO6vLrNjXjBSahMHUpnG3DHdR57auDdeaIevWSkx2hJpAMMhFg==",
       "requires": {
-        "@aws-sdk/middleware-bucket-endpoint": "3.209.0",
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.212.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -8727,12 +10454,19 @@
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.208.0.tgz",
-      "integrity": "sha512-Kx3Z8RQu/tHTDTBQPXT3SyvsW8KxoNPBxP2d84Gugb6Pj766fZlYj7qOqWTSx+aCOSOIHcPjxilgTNJ6VBbJmA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.212.0.tgz",
+      "integrity": "sha512-LmBbOgwwLMRatYsYAnasDmCEb7O11LkQKapFgj5Woi3qCW6U6TKP5+ucjou35AAPgZhwcaYDRK2nHcEPH1xGiA==",
       "requires": {
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/types": "3.212.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/middleware-stack": {
@@ -8841,15 +10575,52 @@
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.208.0.tgz",
-      "integrity": "sha512-7CZtIxj+hlBvGKjz/8BweLIEdTZdtSiyH9RuW2Oue25RF3YPtKpwanlV7obk/+UIVh36oe1EWaXEBbS0h68GhA==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.212.0.tgz",
+      "integrity": "sha512-d/L2dkpxBtVBFQGc3RLkoOrPj7TWY8eQM4enD56tBAOwgMdrl42hYHmbrAeTJ3Q6Seyht71XIjez+o97qF7QFg==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.208.0",
-        "@aws-sdk/signature-v4": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/protocol-http": "3.212.0",
+        "@aws-sdk/signature-v4": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-arn-parser": "3.208.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
+          "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-hex-encoding": "3.201.0",
+            "@aws-sdk/util-middleware": "3.212.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
+          "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/smithy-client": {
@@ -8997,27 +10768,112 @@
       }
     },
     "@aws-sdk/util-stream-browser": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.208.0.tgz",
-      "integrity": "sha512-zKAwaMn7tLLTA1uZFL0Ynomxu/EVeUa2VKxB+y87g3hHZmC11QQ5rOiNTnvYzy6w3BsssWNYzazom3jNhpWvtQ==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.212.0.tgz",
+      "integrity": "sha512-WuWZdSeqDD8IQq78rstJX/bdWtdEtnYkfIm79xa41YB8WTuynz+ijg26YcXRrq5JAtWCEw+2BUceyV+7dYWqrg==",
       "requires": {
-        "@aws-sdk/fetch-http-handler": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/fetch-http-handler": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-base64": "3.208.0",
         "@aws-sdk/util-hex-encoding": "3.201.0",
         "@aws-sdk/util-utf8-browser": "3.188.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
+          "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/querystring-builder": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-base64": "3.208.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+          "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/util-stream-node": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.208.0.tgz",
-      "integrity": "sha512-2/gB8QchikmrxOBNVytviX8j1H6GZg/TKdUiUlLg5/x7I2EMlaKZK3FI7In80gqwoG6C7h8NwEIvpfmbhl7gAw==",
+      "version": "3.212.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.212.0.tgz",
+      "integrity": "sha512-Nmtg1H/Xgbn+j4tq4sq8l9YkzFtajWp+Wrl1maoNCzcd9xGtUkfQVT35XXvveIoAZZe5fW/kM1zrxINjjlL/6w==",
       "requires": {
-        "@aws-sdk/node-http-handler": "3.208.0",
-        "@aws-sdk/types": "3.208.0",
+        "@aws-sdk/node-http-handler": "3.212.0",
+        "@aws-sdk/types": "3.212.0",
         "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
+          "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
+          "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.212.0",
+            "@aws-sdk/protocol-http": "3.212.0",
+            "@aws-sdk/querystring-builder": "3.212.0",
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+          "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+          "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
+          "requires": {
+            "@aws-sdk/types": "3.212.0",
+            "@aws-sdk/util-uri-escape": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.212.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+          "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        }
       }
     },
     "@aws-sdk/util-uri-escape": {

--- a/src/package.json
+++ b/src/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.211.0",
-    "@aws-sdk/client-s3": "^3.211.0",
+    "@aws-sdk/client-s3": "^3.212.0",
     "express": "^4.18.2"
   },
   "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.209.0",
+    "@aws-sdk/client-dynamodb": "^3.210.0",
     "@aws-sdk/client-s3": "^3.209.0",
     "express": "^4.18.2"
   },

--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.211.0",
+    "@aws-sdk/client-dynamodb": "^3.212.0",
     "@aws-sdk/client-s3": "^3.212.0",
     "express": "^4.18.2"
   },

--- a/src/package.json
+++ b/src/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.210.0",
-    "@aws-sdk/client-s3": "^3.209.0",
+    "@aws-sdk/client-s3": "^3.210.0",
     "express": "^4.18.2"
   },
   "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.210.0",
+    "@aws-sdk/client-dynamodb": "^3.211.0",
     "@aws-sdk/client-s3": "^3.210.0",
     "express": "^4.18.2"
   },

--- a/src/package.json
+++ b/src/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.208.0",
-    "@aws-sdk/client-s3": "^3.208.0",
+    "@aws-sdk/client-s3": "^3.209.0",
     "express": "^4.18.2"
   },
   "devDependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.208.0",
+    "@aws-sdk/client-dynamodb": "^3.209.0",
     "@aws-sdk/client-s3": "^3.209.0",
     "express": "^4.18.2"
   },

--- a/src/package.json
+++ b/src/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.211.0",
-    "@aws-sdk/client-s3": "^3.210.0",
+    "@aws-sdk/client-s3": "^3.211.0",
     "express": "^4.18.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit https://github.com/byu-oit/hw-fargate-api/commit/364cd569ca1bd97a5eba6b3ccb946a6487ba1059. We also bring a handful of small Dependabot updates along for the ride.

It appears that hadolint-action@v3.0.0 likely has a regression and isn't actually printing out errors (and creating helpful annotations) any more. It's a shame, because moving to v3.0.0 finally removed the pesky warning about GitHub's `set-output` deprecation.

See: [check results for v3.0.0](https://github.com/byu-oit/hw-fargate-api/actions/runs/3492488843/jobs/5846323737) vs [v2.1.0](https://github.com/byu-oit/hw-fargate-api/actions/runs/3492569980/jobs/5846491216).