### PR TITLE
Simplify job names when using matrices

### DIFF
--- a/.github/workflows/ci-iac.yml
+++ b/.github/workflows/ci-iac.yml
@@ -86,7 +86,7 @@ jobs:
         run: terraform fmt -check -recursive
 
   plan:
-    name: Terraform Plan (${{ matrix.env.environment_name }})
+    name: Terraform Plan / ${{ matrix.env.environment_name }}
     runs-on: ubuntu-latest
     needs: env
     strategy:

--- a/.github/workflows/ci-iac.yml
+++ b/.github/workflows/ci-iac.yml
@@ -22,6 +22,7 @@ jobs:
           matrix='{
             "env":[
               {
+                "environment_name":"dev",
                 "tf_working_dir":"./terraform-iac/dev/app",
                 "aws_account":"977306314792",
                 "aws_gha_role":"hw-fargate-api-dev-gha"
@@ -36,6 +37,7 @@ jobs:
           matrix='{
             "env":[
               {
+                "environment_name":"stg",
                 "tf_working_dir":"./terraform-iac/stg/app",
                 "aws_account":"977306314792",
                 "aws_gha_role":"hw-fargate-api-stg-gha"
@@ -50,11 +52,13 @@ jobs:
           matrix='{
             "env":[
               {
+                "environment_name":"prd",
                 "tf_working_dir":"./terraform-iac/prd/app",
                 "aws_account":"539738229445",
                 "aws_gha_role":"hw-fargate-api-prd-gha"
               },
               {
+                "environment_name":"cpy",
                 "tf_working_dir":"./terraform-iac/cpy/app",
                 "aws_account":"539738229445",
                 "aws_gha_role":"hw-fargate-api-cpy-gha"
@@ -82,7 +86,7 @@ jobs:
         run: terraform fmt -check -recursive
 
   plan:
-    name: Terraform Plan
+    name: Terraform Plan (${{ matrix.env.environment_name }})
     runs-on: ubuntu-latest
     needs: env
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,7 @@ jobs:
         run: terraform fmt -check -recursive
 
   build_and_deploy:
-    name: Build and Deploy (${{ matrix.env.environment_name }})
+    name: Build and Deploy / ${{ matrix.env.environment_name }}
     runs-on: ubuntu-latest
     needs: [env, test, audit, lint, hadolint, format]
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,7 +185,7 @@ jobs:
         run: terraform fmt -check -recursive
 
   build_and_deploy:
-    name: Build and Deploy
+    name: Build and Deploy (${{ matrix.env.environment_name }})
     runs-on: ubuntu-latest
     needs: [env, test, audit, lint, hadolint, format]
     strategy:


### PR DESCRIPTION
The docs are unclear on if `${{ matrix.env.environment_name }}` would be available for job names. If it works in CI, it should also work in deployments.

This is an attempt to simplify
![image](https://user-images.githubusercontent.com/7625337/225707132-dcc8cd2f-c5b9-453b-b5aa-60d7f3ed41dd.png)
to show

> Build and Deploy (cpy)

instead.